### PR TITLE
feat: improve folder loading performance by implementing shallow read…

### DIFF
--- a/backend/src/main/java/cloudpage/controller/FolderController.java
+++ b/backend/src/main/java/cloudpage/controller/FolderController.java
@@ -56,26 +56,35 @@ public class FolderController {
   }
 
   @PostMapping
-  public FolderDto createFolder(@RequestParam String parentPath, @RequestParam String name)
+  public FolderDto createFolder(
+      @RequestParam String parentPath,
+      @RequestParam String name,
+      @RequestParam(required = false, defaultValue = "false") boolean includeChildCounts)
       throws IOException {
     var user = userService.getCurrentUser();
     folderService.createFolder(user.getRootFolderPath(), parentPath, name);
-    return folderService.getFolderTree(user.getRootFolderPath());
+    return folderService.getFolderTree(user.getRootFolderPath(), includeChildCounts);
   }
 
   @DeleteMapping
-  public FolderDto deleteFolder(@RequestParam String folderPath) throws IOException {
+  public FolderDto deleteFolder(
+      @RequestParam String folderPath,
+      @RequestParam(required = false, defaultValue = "false") boolean includeChildCounts)
+      throws IOException {
     var user = userService.getCurrentUser();
     folderService.deleteFolder(user.getRootFolderPath(), folderPath);
-    return folderService.getFolderTree(user.getRootFolderPath());
+    return folderService.getFolderTree(user.getRootFolderPath(), includeChildCounts);
   }
 
   @PatchMapping
-  public FolderDto renameOrMoveFolder(@RequestParam String folderPath, @RequestParam String newPath)
+  public FolderDto renameOrMoveFolder(
+      @RequestParam String folderPath,
+      @RequestParam String newPath,
+      @RequestParam(required = false, defaultValue = "false") boolean includeChildCounts)
       throws IOException {
     var user = userService.getCurrentUser();
     folderService.renameOrMoveFolder(user.getRootFolderPath(), folderPath, newPath);
-    return folderService.getFolderTree(user.getRootFolderPath());
+    return folderService.getFolderTree(user.getRootFolderPath(), includeChildCounts);
   }
 
   @GetMapping("/search")

--- a/backend/src/main/java/cloudpage/controller/FolderController.java
+++ b/backend/src/main/java/cloudpage/controller/FolderController.java
@@ -21,9 +21,11 @@ public class FolderController {
   private final UserService userService;
 
   @GetMapping
-  public FolderDto getUserRootFolder() throws IOException {
+  public FolderDto getUserRootFolder(
+      @RequestParam(required = false, defaultValue = "false") boolean includeChildCounts)
+      throws IOException {
     var user = userService.getCurrentUser();
-    return folderService.getFolderTree(user.getRootFolderPath());
+    return folderService.getFolderTree(user.getRootFolderPath(), includeChildCounts);
   }
 
   @GetMapping("/content")
@@ -45,9 +47,12 @@ public class FolderController {
   }
 
   @GetMapping("/path")
-  public FolderDto getFolderByPath(@RequestParam String path) throws IOException {
+  public FolderDto getFolderByPath(
+      @RequestParam String path,
+      @RequestParam(required = false, defaultValue = "false") boolean includeChildCounts)
+      throws IOException {
     var user = userService.getCurrentUser();
-    return folderService.getFolderTree(user.getRootFolderPath(), path);
+    return folderService.getFolderTree(user.getRootFolderPath(), path, includeChildCounts);
   }
 
   @PostMapping

--- a/backend/src/main/java/cloudpage/dto/FolderDto.java
+++ b/backend/src/main/java/cloudpage/dto/FolderDto.java
@@ -14,4 +14,5 @@ public class FolderDto {
   private List<FolderDto> folders;
   private List<FileDto> files;
   private long lastModifiedAt;
+  private long directChildrenCount;
 }

--- a/backend/src/main/java/cloudpage/dto/FolderListItemDto.java
+++ b/backend/src/main/java/cloudpage/dto/FolderListItemDto.java
@@ -1,6 +1,5 @@
 package cloudpage.dto;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,10 +7,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class FolderDto {
+public class FolderListItemDto {
   private String name;
   private String path;
-  private List<FolderListItemDto> folders;
-  private List<FileDto> files;
+  private long directChildrenCount;
   private long lastModifiedAt;
 }

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -103,13 +103,13 @@ public class FolderService {
   public FolderDto getFolderTree(String rootPath) throws IOException {
     Path root = Paths.get(rootPath);
     validateRoot(root);
-    return readFolder(rootPath, root);
+    return readFolderShallow(rootPath, root);
   }
 
   public FolderDto getFolderTree(String rootPath, String relativePath) throws IOException {
     Path folder = Paths.get(rootPath, relativePath).normalize();
     validatePath(rootPath, folder);
-    return readFolder(rootPath, folder);
+    return readFolderShallow(rootPath, folder);
   }
 
   public Path createFolder(String rootPath, String relativeParentPath, String name)
@@ -277,74 +277,32 @@ public class FolderService {
     items.sort(comparator);
   }
 
-  private FolderDto readFolder(String rootPath, Path path) throws IOException {
+  private FolderDto readFolderShallow(String rootPath, Path path) throws IOException {
     // Resolve root path once for relative path calculation
     Path rootReal = Paths.get(rootPath).toRealPath().normalize();
 
-    List<FolderDto> subfolders;
+    List<FolderDto> subfolders = new ArrayList<>();
+    List<FileDto> files = new ArrayList<>();
     try (var stream = Files.list(path)) {
-      subfolders =
-          stream
-              .filter(Files::isDirectory)
-              .map(
-                  subPath -> {
-                    try {
-                      // Validate each child path to prevent symlink escapes
-                      validatePath(rootPath, subPath);
-                      return readFolder(rootPath, subPath);
-                    } catch (IOException e) {
-                      throw new InvalidPathException(
-                          "Invalid path detected while reading folder: "
-                              + subPath
-                              + " - "
-                              + e.getMessage());
-                    }
-                  })
-              .collect(Collectors.toList());
-    }
+      stream.forEach(
+          childPath -> {
+            try {
+              // Validate each child path to prevent symlink escapes
+              validatePath(rootPath, childPath);
+            } catch (IOException e) {
+              throw new InvalidPathException(
+                  "Invalid path detected while reading folder: "
+                      + childPath
+                      + " - "
+                      + e.getMessage());
+            }
 
-    List<FileDto> files;
-    try (var stream = Files.list(path)) {
-      files =
-          stream
-              .filter(Files::isRegularFile)
-              .map(
-                  filePath -> {
-                    try {
-                      // Validate each child path to prevent symlink escapes
-                      validatePath(rootPath, filePath);
-
-                      // Calculate relative path from root to file
-                      String relativePath;
-                      try {
-                        Path filePathReal = filePath.toRealPath().normalize();
-                        relativePath = rootReal.relativize(filePathReal).toString();
-                        // Use forward slashes for consistency across platforms
-                        relativePath = relativePath.replace('\\', '/');
-                      } catch (IOException e) {
-                        // Fallback to simple relativize if toRealPath fails
-                        relativePath =
-                            Paths.get(rootPath).relativize(filePath.toAbsolutePath()).toString();
-                        relativePath = relativePath.replace('\\', '/');
-                      }
-
-                      BasicFileAttributes attrs =
-                          Files.readAttributes(filePath, BasicFileAttributes.class);
-                      return new FileDto(
-                          filePath.getFileName().toString(),
-                          relativePath,
-                          attrs.size(),
-                          Files.probeContentType(filePath),
-                          attrs.lastModifiedTime().toMillis());
-                    } catch (IOException e) {
-                      throw new FileAccessException(
-                          "Failed to read file attributes: "
-                              + filePath
-                              + " with exception: "
-                              + e.getMessage());
-                    }
-                  })
-              .collect(Collectors.toList());
+            if (Files.isDirectory(childPath)) {
+              subfolders.add(toShallowFolderDto(rootPath, rootReal, childPath));
+            } else if (Files.isRegularFile(childPath)) {
+              files.add(toFileDto(rootPath, rootReal, childPath));
+            }
+          });
     }
 
     // Calculate relative path for the current folder
@@ -374,10 +332,80 @@ public class FolderService {
           folderRelativePath,
           subfolders,
           files,
-          folderAttrs.lastModifiedTime().toMillis());
+          folderAttrs.lastModifiedTime().toMillis(),
+          subfolders.size() + files.size());
     } catch (IOException e) {
       throw new FileAccessException(
           "Failed to read folder attributes: " + path + " with exception: " + e.getMessage());
+    }
+  }
+
+  private FolderDto toShallowFolderDto(String rootPath, Path rootReal, Path path) {
+    String folderRelativePath;
+    try {
+      Path pathReal = path.toRealPath().normalize();
+      folderRelativePath = rootReal.relativize(pathReal).toString();
+      folderRelativePath = folderRelativePath.replace('\\', '/');
+      if (folderRelativePath.isEmpty()) {
+        folderRelativePath = ".";
+      }
+    } catch (IOException e) {
+      folderRelativePath = Paths.get(rootPath).relativize(path.toAbsolutePath()).toString();
+      folderRelativePath = folderRelativePath.replace('\\', '/');
+      if (folderRelativePath.isEmpty()) {
+        folderRelativePath = ".";
+      }
+    }
+
+    try {
+      BasicFileAttributes folderAttrs = Files.readAttributes(path, BasicFileAttributes.class);
+      return new FolderDto(
+          path.getFileName().toString(),
+          folderRelativePath,
+          List.of(),
+          List.of(),
+          folderAttrs.lastModifiedTime().toMillis(),
+          countDirectChildren(path));
+    } catch (IOException e) {
+      throw new FileAccessException(
+          "Failed to read folder attributes: " + path + " with exception: " + e.getMessage());
+    }
+  }
+
+  private FileDto toFileDto(String rootPath, Path rootReal, Path filePath) {
+    try {
+      String relativePath;
+      try {
+        Path filePathReal = filePath.toRealPath().normalize();
+        relativePath = rootReal.relativize(filePathReal).toString();
+        relativePath = relativePath.replace('\\', '/');
+      } catch (IOException e) {
+        relativePath = Paths.get(rootPath).relativize(filePath.toAbsolutePath()).toString();
+        relativePath = relativePath.replace('\\', '/');
+      }
+
+      BasicFileAttributes attrs = Files.readAttributes(filePath, BasicFileAttributes.class);
+      return new FileDto(
+          filePath.getFileName().toString(),
+          relativePath,
+          attrs.size(),
+          Files.probeContentType(filePath),
+          attrs.lastModifiedTime().toMillis());
+    } catch (IOException e) {
+      throw new FileAccessException(
+          "Failed to read file attributes: " + filePath + " with exception: " + e.getMessage());
+    }
+  }
+
+  private long countDirectChildren(Path directoryPath) {
+    try (var stream = Files.list(directoryPath)) {
+      return stream.count();
+    } catch (IOException e) {
+      throw new FileAccessException(
+          "Failed to count direct children for: "
+              + directoryPath
+              + " with exception: "
+              + e.getMessage());
     }
   }
 

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -101,15 +101,24 @@ public class FolderService {
   }
 
   public FolderDto getFolderTree(String rootPath) throws IOException {
+    return getFolderTree(rootPath, false);
+  }
+
+  public FolderDto getFolderTree(String rootPath, boolean includeChildCounts) throws IOException {
     Path root = Paths.get(rootPath);
     validateRoot(root);
-    return readFolderShallow(rootPath, root);
+    return readFolderShallow(rootPath, root, includeChildCounts);
   }
 
   public FolderDto getFolderTree(String rootPath, String relativePath) throws IOException {
+    return getFolderTree(rootPath, relativePath, false);
+  }
+
+  public FolderDto getFolderTree(String rootPath, String relativePath, boolean includeChildCounts)
+      throws IOException {
     Path folder = Paths.get(rootPath, relativePath).normalize();
     validatePath(rootPath, folder);
-    return readFolderShallow(rootPath, folder);
+    return readFolderShallow(rootPath, folder, includeChildCounts);
   }
 
   public Path createFolder(String rootPath, String relativeParentPath, String name)
@@ -167,7 +176,7 @@ public class FolderService {
       throw new InvalidPathException("Folder does not exist or is not a directory: " + folder);
     }
 
-    // Resolve root path once for relative path calculation
+    // Resolve root path once for relative path calculation and path validation
     Path rootReal = Paths.get(rootPath).toRealPath().normalize();
 
     List<FolderContentItemDto> items = new ArrayList<>();
@@ -179,7 +188,7 @@ public class FolderService {
                   path -> {
                     // Validate each child path to prevent symlink escapes
                     try {
-                      validatePath(rootPath, path);
+                      validatePath(rootReal, path);
                     } catch (IOException e) {
                       throw new InvalidPathException(
                           "Invalid path detected while listing: " + path + " - " + e.getMessage());
@@ -277,18 +286,19 @@ public class FolderService {
     items.sort(comparator);
   }
 
-  private FolderDto readFolderShallow(String rootPath, Path path) throws IOException {
-    // Resolve root path once for relative path calculation
+  private FolderDto readFolderShallow(String rootPath, Path path, boolean includeChildCounts)
+      throws IOException {
+    // Resolve root path once for relative path calculation and path validation
     Path rootReal = Paths.get(rootPath).toRealPath().normalize();
 
-    List<FolderDto> subfolders = new ArrayList<>();
+    List<FolderListItemDto> subfolders = new ArrayList<>();
     List<FileDto> files = new ArrayList<>();
     try (var stream = Files.list(path)) {
       stream.forEach(
           childPath -> {
             try {
               // Validate each child path to prevent symlink escapes
-              validatePath(rootPath, childPath);
+              validatePath(rootReal, childPath);
             } catch (IOException e) {
               throw new InvalidPathException(
                   "Invalid path detected while reading folder: "
@@ -298,7 +308,8 @@ public class FolderService {
             }
 
             if (Files.isDirectory(childPath)) {
-              subfolders.add(toShallowFolderDto(rootPath, rootReal, childPath));
+              subfolders.add(
+                  toFolderListItemDto(rootPath, rootReal, childPath, includeChildCounts));
             } else if (Files.isRegularFile(childPath)) {
               files.add(toFileDto(rootPath, rootReal, childPath));
             }
@@ -332,15 +343,15 @@ public class FolderService {
           folderRelativePath,
           subfolders,
           files,
-          folderAttrs.lastModifiedTime().toMillis(),
-          subfolders.size() + files.size());
+          folderAttrs.lastModifiedTime().toMillis());
     } catch (IOException e) {
       throw new FileAccessException(
           "Failed to read folder attributes: " + path + " with exception: " + e.getMessage());
     }
   }
 
-  private FolderDto toShallowFolderDto(String rootPath, Path rootReal, Path path) {
+  private FolderListItemDto toFolderListItemDto(
+      String rootPath, Path rootReal, Path path, boolean includeChildCounts) {
     String folderRelativePath;
     try {
       Path pathReal = path.toRealPath().normalize();
@@ -359,13 +370,11 @@ public class FolderService {
 
     try {
       BasicFileAttributes folderAttrs = Files.readAttributes(path, BasicFileAttributes.class);
-      return new FolderDto(
+      return new FolderListItemDto(
           path.getFileName().toString(),
           folderRelativePath,
-          List.of(),
-          List.of(),
-          folderAttrs.lastModifiedTime().toMillis(),
-          countDirectChildren(path));
+          includeChildCounts ? countDirectChildren(rootReal, path) : -1L,
+          folderAttrs.lastModifiedTime().toMillis());
     } catch (IOException e) {
       throw new FileAccessException(
           "Failed to read folder attributes: " + path + " with exception: " + e.getMessage());
@@ -397,9 +406,23 @@ public class FolderService {
     }
   }
 
-  private long countDirectChildren(Path directoryPath) {
+  private long countDirectChildren(Path rootReal, Path directoryPath) {
     try (var stream = Files.list(directoryPath)) {
-      return stream.count();
+      return stream
+          .filter(
+              childPath -> {
+                try {
+                  validatePath(rootReal, childPath);
+                } catch (IOException e) {
+                  throw new InvalidPathException(
+                      "Invalid path detected while counting: "
+                          + childPath
+                          + " - "
+                          + e.getMessage());
+                }
+                return Files.isDirectory(childPath) || Files.isRegularFile(childPath);
+              })
+          .count();
     } catch (IOException e) {
       throw new FileAccessException(
           "Failed to count direct children for: "
@@ -411,6 +434,10 @@ public class FolderService {
 
   public void validatePath(String rootPath, Path path) throws IOException {
     Path rootReal = Paths.get(rootPath).toRealPath().normalize();
+    validatePath(rootReal, path);
+  }
+
+  private void validatePath(Path rootReal, Path path) throws IOException {
     Path pathReal;
 
     // If path exists, resolve symlinks to get the real path

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -186,58 +186,44 @@ public class FolderService {
           stream
               .map(
                   path -> {
-                    // Validate each child path to prevent symlink escapes
                     try {
-                      validatePath(rootReal, path);
+                      Path pathReal = resolvePathWithinRoot(rootReal, path);
+                      String itemRelativePath = toRelativePath(rootReal, pathReal);
+
+                      boolean isDirectory = Files.isDirectory(path);
+                      long sizeValue = 0L;
+                      String mimeType = null;
+                      long lastModifiedAt;
+
+                      try {
+                        BasicFileAttributes attrs =
+                            Files.readAttributes(path, BasicFileAttributes.class);
+
+                        lastModifiedAt = attrs.lastModifiedTime().toMillis();
+
+                        if (!isDirectory) {
+                          sizeValue = attrs.size();
+                          mimeType = Files.probeContentType(path);
+                        }
+                      } catch (IOException e) {
+                        throw new FileAccessException(
+                            "Failed to read file attributes: "
+                                + path
+                                + " with exception: "
+                                + e.getMessage());
+                      }
+
+                      return new FolderContentItemDto(
+                          path.getFileName().toString(),
+                          itemRelativePath,
+                          isDirectory,
+                          sizeValue,
+                          mimeType,
+                          lastModifiedAt);
                     } catch (IOException e) {
                       throw new InvalidPathException(
                           "Invalid path detected while listing: " + path + " - " + e.getMessage());
                     }
-
-                    // Calculate relative path from root to child
-                    String itemRelativePath;
-                    try {
-                      Path pathReal = path.toRealPath().normalize();
-                      itemRelativePath = rootReal.relativize(pathReal).toString();
-                      // Use forward slashes for consistency across platforms
-                      itemRelativePath = itemRelativePath.replace('\\', '/');
-                    } catch (IOException e) {
-                      // Fallback to simple relativize if toRealPath fails
-                      itemRelativePath =
-                          Paths.get(rootPath).relativize(path.toAbsolutePath()).toString();
-                      itemRelativePath = itemRelativePath.replace('\\', '/');
-                    }
-
-                    boolean isDirectory = Files.isDirectory(path);
-                    long sizeValue = 0L;
-                    String mimeType = null;
-                    long lastModifiedAt;
-
-                    try {
-                      BasicFileAttributes attrs =
-                          Files.readAttributes(path, BasicFileAttributes.class);
-
-                      lastModifiedAt = attrs.lastModifiedTime().toMillis();
-
-                      if (!isDirectory) {
-                        sizeValue = attrs.size();
-                        mimeType = Files.probeContentType(path);
-                      }
-                    } catch (IOException e) {
-                      throw new FileAccessException(
-                          "Failed to read file attributes: "
-                              + path
-                              + " with exception: "
-                              + e.getMessage());
-                    }
-
-                    return new FolderContentItemDto(
-                        path.getFileName().toString(),
-                        itemRelativePath,
-                        isDirectory,
-                        sizeValue,
-                        mimeType,
-                        lastModifiedAt);
                   })
               .collect(Collectors.toList());
     }
@@ -290,6 +276,7 @@ public class FolderService {
       throws IOException {
     // Resolve root path once for relative path calculation and path validation
     Path rootReal = Paths.get(rootPath).toRealPath().normalize();
+    Path folderPathReal = resolvePathWithinRoot(rootReal, path);
 
     List<FolderListItemDto> subfolders = new ArrayList<>();
     List<FileDto> files = new ArrayList<>();
@@ -297,8 +284,15 @@ public class FolderService {
       stream.forEach(
           childPath -> {
             try {
-              // Validate each child path to prevent symlink escapes
-              validatePath(rootReal, childPath);
+              // Resolve and validate once per child to avoid repeated toRealPath() calls.
+              Path childPathReal = resolvePathWithinRoot(rootReal, childPath);
+
+              if (Files.isDirectory(childPath)) {
+                subfolders.add(
+                    toFolderListItemDto(rootReal, childPath, childPathReal, includeChildCounts));
+              } else if (Files.isRegularFile(childPath)) {
+                files.add(toFileDto(rootReal, childPath, childPathReal));
+              }
             } catch (IOException e) {
               throw new InvalidPathException(
                   "Invalid path detected while reading folder: "
@@ -306,35 +300,11 @@ public class FolderService {
                       + " - "
                       + e.getMessage());
             }
-
-            if (Files.isDirectory(childPath)) {
-              subfolders.add(
-                  toFolderListItemDto(rootPath, rootReal, childPath, includeChildCounts));
-            } else if (Files.isRegularFile(childPath)) {
-              files.add(toFileDto(rootPath, rootReal, childPath));
-            }
           });
     }
 
     // Calculate relative path for the current folder
-    String folderRelativePath;
-    try {
-      Path pathReal = path.toRealPath().normalize();
-      folderRelativePath = rootReal.relativize(pathReal).toString();
-      // Use forward slashes for consistency across platforms
-      folderRelativePath = folderRelativePath.replace('\\', '/');
-      // Empty string means root folder
-      if (folderRelativePath.isEmpty()) {
-        folderRelativePath = ".";
-      }
-    } catch (IOException e) {
-      // Fallback to simple relativize if toRealPath fails
-      folderRelativePath = Paths.get(rootPath).relativize(path.toAbsolutePath()).toString();
-      folderRelativePath = folderRelativePath.replace('\\', '/');
-      if (folderRelativePath.isEmpty()) {
-        folderRelativePath = ".";
-      }
-    }
+    String folderRelativePath = toRelativePath(rootReal, folderPathReal);
 
     try {
       BasicFileAttributes folderAttrs = Files.readAttributes(path, BasicFileAttributes.class);
@@ -351,22 +321,8 @@ public class FolderService {
   }
 
   private FolderListItemDto toFolderListItemDto(
-      String rootPath, Path rootReal, Path path, boolean includeChildCounts) {
-    String folderRelativePath;
-    try {
-      Path pathReal = path.toRealPath().normalize();
-      folderRelativePath = rootReal.relativize(pathReal).toString();
-      folderRelativePath = folderRelativePath.replace('\\', '/');
-      if (folderRelativePath.isEmpty()) {
-        folderRelativePath = ".";
-      }
-    } catch (IOException e) {
-      folderRelativePath = Paths.get(rootPath).relativize(path.toAbsolutePath()).toString();
-      folderRelativePath = folderRelativePath.replace('\\', '/');
-      if (folderRelativePath.isEmpty()) {
-        folderRelativePath = ".";
-      }
-    }
+      Path rootReal, Path path, Path pathReal, boolean includeChildCounts) {
+    String folderRelativePath = toRelativePath(rootReal, pathReal);
 
     try {
       BasicFileAttributes folderAttrs = Files.readAttributes(path, BasicFileAttributes.class);
@@ -381,17 +337,9 @@ public class FolderService {
     }
   }
 
-  private FileDto toFileDto(String rootPath, Path rootReal, Path filePath) {
+  private FileDto toFileDto(Path rootReal, Path filePath, Path filePathReal) {
     try {
-      String relativePath;
-      try {
-        Path filePathReal = filePath.toRealPath().normalize();
-        relativePath = rootReal.relativize(filePathReal).toString();
-        relativePath = relativePath.replace('\\', '/');
-      } catch (IOException e) {
-        relativePath = Paths.get(rootPath).relativize(filePath.toAbsolutePath()).toString();
-        relativePath = relativePath.replace('\\', '/');
-      }
+      String relativePath = toRelativePath(rootReal, filePathReal);
 
       BasicFileAttributes attrs = Files.readAttributes(filePath, BasicFileAttributes.class);
       return new FileDto(
@@ -434,10 +382,14 @@ public class FolderService {
 
   public void validatePath(String rootPath, Path path) throws IOException {
     Path rootReal = Paths.get(rootPath).toRealPath().normalize();
-    validatePath(rootReal, path);
+    resolvePathWithinRoot(rootReal, path);
   }
 
   private void validatePath(Path rootReal, Path path) throws IOException {
+    resolvePathWithinRoot(rootReal, path);
+  }
+
+  private Path resolvePathWithinRoot(Path rootReal, Path path) throws IOException {
     Path pathReal;
 
     // If path exists, resolve symlinks to get the real path
@@ -469,6 +421,13 @@ public class FolderService {
     if (!pathReal.startsWith(rootReal)) {
       throw new InvalidPathException("Path traversal attempt detected: " + path);
     }
+
+    return pathReal;
+  }
+
+  private String toRelativePath(Path rootReal, Path pathReal) {
+    String relativePath = rootReal.relativize(pathReal).toString().replace('\\', '/');
+    return relativePath.isEmpty() ? "." : relativePath;
   }
 
   private void validateRoot(Path root) {

--- a/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
@@ -59,7 +59,8 @@ class FolderControllerTest {
             tempDir.toString(),
             Collections.emptyList(),
             Collections.emptyList(),
-            FIXED_TIME);
+            FIXED_TIME,
+            0L);
   }
 
   // ── GET /api/folders ─────────────────────────────────────────────────────
@@ -86,7 +87,8 @@ class FolderControllerTest {
             tempDir.resolve("docs").toString(),
             Collections.emptyList(),
             Collections.emptyList(),
-            FIXED_TIME);
+            FIXED_TIME,
+            0L);
     when(folderService.getFolderTree(tempDir.toString(), "docs")).thenReturn(subFolder);
 
     mockMvc

--- a/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
@@ -59,15 +59,14 @@ class FolderControllerTest {
             tempDir.toString(),
             Collections.emptyList(),
             Collections.emptyList(),
-            FIXED_TIME,
-            0L);
+            FIXED_TIME);
   }
 
   // ── GET /api/folders ─────────────────────────────────────────────────────
 
   @Test
   void getUserRootFolder_returnsRootFolderDto() throws Exception {
-    when(folderService.getFolderTree(tempDir.toString())).thenReturn(rootFolder);
+    when(folderService.getFolderTree(tempDir.toString(), false)).thenReturn(rootFolder);
 
     mockMvc
         .perform(get("/api/folders"))
@@ -87,9 +86,8 @@ class FolderControllerTest {
             tempDir.resolve("docs").toString(),
             Collections.emptyList(),
             Collections.emptyList(),
-            FIXED_TIME,
-            0L);
-    when(folderService.getFolderTree(tempDir.toString(), "docs")).thenReturn(subFolder);
+            FIXED_TIME);
+    when(folderService.getFolderTree(tempDir.toString(), "docs", false)).thenReturn(subFolder);
 
     mockMvc
         .perform(get("/api/folders/path").param("path", "docs"))
@@ -100,7 +98,7 @@ class FolderControllerTest {
 
   @Test
   void getFolderByPath_invalidPath_returns400() throws Exception {
-    when(folderService.getFolderTree(tempDir.toString(), "../../evil"))
+    when(folderService.getFolderTree(tempDir.toString(), "../../evil", false))
         .thenThrow(new InvalidPathException("Access outside the user's root folder is forbidden"));
 
     mockMvc

--- a/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
@@ -112,7 +112,7 @@ class FolderControllerTest {
   void createFolder_validRequest_returnsUpdatedTree() throws Exception {
     when(folderService.createFolder(tempDir.toString(), "docs", "newDir"))
         .thenReturn(tempDir.resolve("docs/newDir"));
-    when(folderService.getFolderTree(tempDir.toString())).thenReturn(rootFolder);
+    when(folderService.getFolderTree(tempDir.toString(), false)).thenReturn(rootFolder);
 
     mockMvc
         .perform(post("/api/folders").param("parentPath", "docs").param("name", "newDir"))
@@ -120,6 +120,25 @@ class FolderControllerTest {
         .andExpect(jsonPath("$.name").value("root"));
 
     verify(folderService).createFolder(tempDir.toString(), "docs", "newDir");
+    verify(folderService).getFolderTree(tempDir.toString(), false);
+  }
+
+  @Test
+  void createFolder_includeChildCountsTrue_passesFlagToTreeResponse() throws Exception {
+    when(folderService.createFolder(tempDir.toString(), "docs", "newDir"))
+        .thenReturn(tempDir.resolve("docs/newDir"));
+    when(folderService.getFolderTree(tempDir.toString(), true)).thenReturn(rootFolder);
+
+    mockMvc
+        .perform(
+            post("/api/folders")
+                .param("parentPath", "docs")
+                .param("name", "newDir")
+                .param("includeChildCounts", "true"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("root"));
+
+    verify(folderService).getFolderTree(tempDir.toString(), true);
   }
 
   @Test
@@ -131,7 +150,7 @@ class FolderControllerTest {
 
   @Test
   void deleteFolder_validRequest_returnsUpdatedTree() throws Exception {
-    when(folderService.getFolderTree(tempDir.toString())).thenReturn(rootFolder);
+    when(folderService.getFolderTree(tempDir.toString(), false)).thenReturn(rootFolder);
 
     mockMvc
         .perform(delete("/api/folders").param("folderPath", "oldDir"))
@@ -139,13 +158,27 @@ class FolderControllerTest {
         .andExpect(jsonPath("$.name").value("root"));
 
     verify(folderService).deleteFolder(tempDir.toString(), "oldDir");
+    verify(folderService).getFolderTree(tempDir.toString(), false);
+  }
+
+  @Test
+  void deleteFolder_includeChildCountsTrue_passesFlagToTreeResponse() throws Exception {
+    when(folderService.getFolderTree(tempDir.toString(), true)).thenReturn(rootFolder);
+
+    mockMvc
+        .perform(delete("/api/folders").param("folderPath", "oldDir").param("includeChildCounts", "true"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("root"));
+
+    verify(folderService).deleteFolder(tempDir.toString(), "oldDir");
+    verify(folderService).getFolderTree(tempDir.toString(), true);
   }
 
   // ── PATCH /api/folders ───────────────────────────────────────────────────
 
   @Test
   void renameOrMoveFolder_validRequest_returnsUpdatedTree() throws Exception {
-    when(folderService.getFolderTree(tempDir.toString())).thenReturn(rootFolder);
+    when(folderService.getFolderTree(tempDir.toString(), false)).thenReturn(rootFolder);
 
     mockMvc
         .perform(patch("/api/folders").param("folderPath", "oldName").param("newPath", "newName"))
@@ -153,6 +186,24 @@ class FolderControllerTest {
         .andExpect(jsonPath("$.name").value("root"));
 
     verify(folderService).renameOrMoveFolder(tempDir.toString(), "oldName", "newName");
+    verify(folderService).getFolderTree(tempDir.toString(), false);
+  }
+
+  @Test
+  void renameOrMoveFolder_includeChildCountsTrue_passesFlagToTreeResponse() throws Exception {
+    when(folderService.getFolderTree(tempDir.toString(), true)).thenReturn(rootFolder);
+
+    mockMvc
+        .perform(
+            patch("/api/folders")
+                .param("folderPath", "oldName")
+                .param("newPath", "newName")
+                .param("includeChildCounts", "true"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("root"));
+
+    verify(folderService).renameOrMoveFolder(tempDir.toString(), "oldName", "newName");
+    verify(folderService).getFolderTree(tempDir.toString(), true);
   }
 
   @Test

--- a/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
@@ -166,7 +166,10 @@ class FolderControllerTest {
     when(folderService.getFolderTree(tempDir.toString(), true)).thenReturn(rootFolder);
 
     mockMvc
-        .perform(delete("/api/folders").param("folderPath", "oldDir").param("includeChildCounts", "true"))
+        .perform(
+            delete("/api/folders")
+                .param("folderPath", "oldDir")
+                .param("includeChildCounts", "true"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.name").value("root"));
 

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -57,8 +57,18 @@ class FolderServiceTest {
     assertEquals(1, tree.getFiles().size());
     assertEquals(1, tree.getFolders().size());
     assertEquals("sub", tree.getFolders().get(0).getName());
-    assertTrue(tree.getFolders().get(0).getFiles().isEmpty());
-    assertTrue(tree.getFolders().get(0).getFolders().isEmpty());
+    assertEquals(-1L, tree.getFolders().get(0).getDirectChildrenCount());
+  }
+
+  @Test
+  void getFolderTree_includeChildCountsTrue_returnsChildCounts() throws IOException {
+    Path sub = Files.createDirectory(tempDir.resolve("sub"));
+    Files.writeString(sub.resolve("child.txt"), "child");
+
+    FolderDto tree = folderService.getFolderTree(tempDir.toString(), true);
+
+    assertEquals(1, tree.getFolders().size());
+    assertEquals(1L, tree.getFolders().get(0).getDirectChildrenCount());
   }
 
   @Test

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -47,7 +47,7 @@ class FolderServiceTest {
   }
 
   @Test
-  void getFolderTree_nestedFoldersWithFiles_returnsFullTree() throws IOException {
+  void getFolderTree_nestedFoldersWithFiles_returnsShallowTree() throws IOException {
     Path sub = Files.createDirectory(tempDir.resolve("sub"));
     Files.writeString(tempDir.resolve("root.txt"), "root");
     Files.writeString(sub.resolve("child.txt"), "child");
@@ -57,8 +57,8 @@ class FolderServiceTest {
     assertEquals(1, tree.getFiles().size());
     assertEquals(1, tree.getFolders().size());
     assertEquals("sub", tree.getFolders().get(0).getName());
-    assertEquals(1, tree.getFolders().get(0).getFiles().size());
-    assertEquals("child.txt", tree.getFolders().get(0).getFiles().get(0).getName());
+    assertTrue(tree.getFolders().get(0).getFiles().isEmpty());
+    assertTrue(tree.getFolders().get(0).getFolders().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
This PR improves Cloud Page folder navigation performance by replacing recursive folder tree loading with shallow reads (single-level listing only).

- Implemented shallow folder reads in `cloud-page` (`FolderService`) to avoid deep recursive filesystem scans.
- Added `directChildrenCount` to `FolderDto` so the UI can still display folder item counts without loading subtrees.
- Updated `vault-web` frontend DTO and Cloud page rendering to use the new count field.
- Adjusted backend tests to match shallow-loading behavior.

## Impact
- Reduced unnecessary filesystem I/O during folder navigation.
- Faster responses for large directory structures.
- Maintains current UX behavior while improving scalability.