### PR TITLE
Fix .zip downloads being saved as .zip.json

### DIFF
--- a/backend/src/main/java/cloudpage/controller/FileController.java
+++ b/backend/src/main/java/cloudpage/controller/FileController.java
@@ -67,10 +67,15 @@ public class FileController {
     folderService.validatePath(user.getRootFolderPath(), fullPath); // ensure security
 
     FileResource result = fileService.loadAsResource(fullPath);
+    String mimeType = Files.probeContentType(fullPath);
+    if (mimeType == null) {
+      mimeType = "application/octet-stream";
+    }
 
     return ResponseEntity.ok()
         .eTag(result.getETag())
         .lastModified(result.getLastModified())
+        .header(HttpHeaders.CONTENT_TYPE, mimeType)
         .header(
             HttpHeaders.CONTENT_DISPOSITION,
             "attachment; filename=\"" + fullPath.getFileName() + "\"")

--- a/backend/src/test/java/cloudpage/controller/FileControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FileControllerTest.java
@@ -117,15 +117,16 @@ class FileControllerTest {
 
   @Test
   void downloadFile_existingFile_returnsResourceWithHeaders() throws Exception {
-    Path file = Files.writeString(tempDir.resolve("download.txt"), "data");
+    Path file = Files.writeString(tempDir.resolve("download.zip"), "data");
     FileResource fileResource =
         new FileResource(new UrlResource(file.toUri()), "\"4-123456\"", 123456L);
     when(fileService.loadAsResource(any(Path.class))).thenReturn(fileResource);
 
     mockMvc
-        .perform(get("/api/files/download").param("path", "download.txt"))
+        .perform(get("/api/files/download").param("path", "download.zip"))
         .andExpect(status().isOk())
-        .andExpect(header().string("Content-Disposition", "attachment; filename=\"download.txt\""))
+        .andExpect(header().string("Content-Disposition", "attachment; filename=\"download.zip\""))
+        .andExpect(header().exists("Content-Type"))
         .andExpect(header().exists("ETag"));
   }
 


### PR DESCRIPTION
## Changes

- Added `Content-Type` handling to the `/download` endpoint using `Files.probeContentType(fullPath)`.
- Added a fallback to `application/octet-stream` when the MIME type cannot be detected.
- Updated the download controller test to use a `.zip` file and assert that `Content-Type` is present.

## Verification

- Ran `.\mvnw.cmd test`
- Result: `BUILD SUCCESS`
- Tests: `88 run, 0 failures, 0 errors, 1 skipped`

Closes #73 