### PR TITLE
feat: include folder sizes in directory content listing

### DIFF
--- a/backend/src/main/java/cloudpage/exceptions/FileAccessException.java
+++ b/backend/src/main/java/cloudpage/exceptions/FileAccessException.java
@@ -9,4 +9,8 @@ public class FileAccessException extends RuntimeException {
   public FileAccessException(String message) {
     super(message);
   }
+
+  public FileAccessException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -7,6 +7,7 @@ import cloudpage.exceptions.FileNotFoundException;
 import cloudpage.exceptions.InvalidPathException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -249,6 +250,9 @@ public class FolderService {
    * it contains. Individual files whose size cannot be read are skipped so that a single
    * inaccessible file does not fail the whole listing.
    *
+   * <p>Symbolic links are not followed, so linked files are not counted and targets outside the
+   * directory tree are ignored.
+   *
    * @param directory the directory whose cumulative size should be calculated
    * @return the total size in bytes of all regular files contained in {@code directory}
    * @throws FileAccessException if the directory tree cannot be traversed
@@ -256,22 +260,20 @@ public class FolderService {
   private long calculateDirectorySize(Path directory) {
     try (var stream = Files.walk(directory)) {
       return stream
-          .filter(Files::isRegularFile)
+          .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
           .mapToLong(
               file -> {
                 try {
-                  return Files.size(file);
+                  return Files.readAttributes(
+                          file, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)
+                      .size();
                 } catch (IOException e) {
                   return 0L;
                 }
               })
           .sum();
     } catch (IOException e) {
-      throw new FileAccessException(
-          "Failed to calculate directory size: "
-              + directory
-              + " with exception: "
-              + e.getMessage());
+      throw new FileAccessException("Failed to calculate directory size: " + directory, e);
     }
   }
 

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -204,6 +204,8 @@ public class FolderService {
                         if (!isDirectory) {
                           sizeValue = attrs.size();
                           mimeType = Files.probeContentType(path);
+                        } else {
+                          sizeValue = calculateDirectorySize(path);
                         }
                       } catch (IOException e) {
                         throw new FileAccessException(
@@ -240,6 +242,37 @@ public class FolderService {
         fromIndex >= items.size() ? List.of() : items.subList(fromIndex, toIndex);
 
     return new PageResponseDto<>(pageContent, totalElements, totalPages, page);
+  }
+
+  /**
+   * Calculates the total size of a directory by recursively summing the sizes of all regular files
+   * it contains. Individual files whose size cannot be read are skipped so that a single
+   * inaccessible file does not fail the whole listing.
+   *
+   * @param directory the directory whose cumulative size should be calculated
+   * @return the total size in bytes of all regular files contained in {@code directory}
+   * @throws FileAccessException if the directory tree cannot be traversed
+   */
+  private long calculateDirectorySize(Path directory) {
+    try (var stream = Files.walk(directory)) {
+      return stream
+          .filter(Files::isRegularFile)
+          .mapToLong(
+              file -> {
+                try {
+                  return Files.size(file);
+                } catch (IOException e) {
+                  return 0L;
+                }
+              })
+          .sum();
+    } catch (IOException e) {
+      throw new FileAccessException(
+          "Failed to calculate directory size: "
+              + directory
+              + " with exception: "
+              + e.getMessage());
+    }
   }
 
   private void applySorting(List<FolderContentItemDto> items, String sort) {

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -463,7 +463,7 @@ class FolderServiceTest {
 
     FolderContentItemDto folderItem =
         result.getContent().stream()
-            .filter(FolderContentItemDto::isDirectory)
+            .filter(item -> item.isDirectory() && item.getName().equals("withFiles"))
             .findFirst()
             .orElseThrow();
     assertEquals("withFiles", folderItem.getName());

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -449,4 +449,25 @@ class FolderServiceTest {
     assertTrue(item.isDirectory());
     assertNotNull(item.getPath());
   }
+
+  @Test
+  void getFolderContentPage_folderWithContents_sizeIsRecursiveSum() throws IOException {
+    Path folder = Files.createDirectory(tempDir.resolve("withFiles"));
+    Files.writeString(folder.resolve("a.txt"), "12345"); // 5 bytes
+    Files.writeString(folder.resolve("b.txt"), "678"); // 3 bytes
+    Path nested = Files.createDirectory(folder.resolve("nested"));
+    Files.writeString(nested.resolve("c.txt"), "90"); // 2 bytes, in a subfolder
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 10, null);
+
+    FolderContentItemDto folderItem =
+        result.getContent().stream()
+            .filter(FolderContentItemDto::isDirectory)
+            .findFirst()
+            .orElseThrow();
+    assertEquals("withFiles", folderItem.getName());
+    // 5 + 3 + 2 -> the folder size includes files in nested subfolders
+    assertEquals(10, folderItem.getSize());
+  }
 }


### PR DESCRIPTION
Closes #55.

## What

When listing directory contents via `GET /folders/content`, files already reported their size, but folders always came back with `size: 0` — in `FolderService.getFolderContentPage`, only files had their size populated.

This computes a folder's size as the **recursive sum of the regular files it contains**, so the core Vault Web frontend can show storage usage for folders as well as files.

## Changes

- **`FolderService`** — add a private `calculateDirectorySize(Path)` helper (`Files.walk` + sum of regular-file sizes) and use it to populate the size of directory entries in `getFolderContentPage`. Individual files whose size can't be read are skipped, so a single inaccessible file does not fail the whole listing.
- **`FolderServiceTest`** — add a test asserting a folder's reported size equals the recursive sum of its contents (including a nested subfolder). The existing empty-folder test (`size == 0`) still holds, since an empty folder sums to 0.

## Verification

- `mvn spotless:check` — clean
- `mvn verify -DskipTests` — success
- `mvn test -Dtest=FolderServiceTest` — 38/38 passing

## Note on performance

Computing a folder's size walks its subtree, which adds I/O to the listing. This is functionally what the issue asks for; if it becomes a concern on large trees it could be cached or made opt-in later (related to #62, which tracks the performance of this endpoint).