### PR TITLE
fix: validate uploaded filename to prevent path traversal

### DIFF
--- a/backend/src/main/java/cloudpage/service/FileService.java
+++ b/backend/src/main/java/cloudpage/service/FileService.java
@@ -33,7 +33,8 @@ public class FileService {
    * @param file the uploaded file
    * @param quotaMb the storage quota in megabytes, or {@code null} for no quota
    * @throws IOException if the folder cannot be created or the file cannot be written
-   * @throws InvalidPathException if the destination is outside the user's root directory
+   * @throws InvalidPathException if the file name is missing or the destination resolves outside
+   *     the user's root directory
    * @throws IllegalArgumentException if the upload would exceed the storage quota
    */
   public void uploadFile(
@@ -59,7 +60,20 @@ public class FileService {
       }
     }
 
-    Path target = folder.resolve(file.getOriginalFilename());
+    String originalFilename = file.getOriginalFilename();
+    if (originalFilename == null || originalFilename.isBlank()) {
+      throw new InvalidPathException("Uploaded file must have a name");
+    }
+
+    // Strip any directory components from the user-supplied name so a crafted filename
+    // (e.g. "../../x" or an absolute path) cannot write outside the user's root directory.
+    Path fileName = Paths.get(originalFilename).getFileName();
+    if (fileName == null) {
+      throw new InvalidPathException("Invalid file name: " + originalFilename);
+    }
+
+    Path target = folder.resolve(fileName).normalize();
+    validatePath(rootPath, target);
     Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
   }
 

--- a/backend/src/test/java/cloudpage/service/FileServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FileServiceTest.java
@@ -74,6 +74,42 @@ class FileServiceTest {
         () -> fileService.uploadFile(tempDir.toString(), "../../etc", file, null));
   }
 
+  @Test
+  void uploadFile_filenameWithTraversal_staysWithinRoot() throws IOException {
+    Path root = Files.createDirectory(tempDir.resolve("root"));
+    MockMultipartFile file =
+        new MockMultipartFile("file", "../../evil.txt", "text/plain", "hack".getBytes());
+
+    fileService.uploadFile(root.toString(), "docs", file, null);
+
+    // The crafted name is reduced to its final component and written inside the folder...
+    assertTrue(Files.exists(root.resolve("docs/evil.txt")));
+    // ...and nothing is written outside the user's root.
+    assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+  }
+
+  @Test
+  void uploadFile_absolutePathFilename_staysWithinRoot() throws IOException {
+    Path root = Files.createDirectory(tempDir.resolve("root"));
+    Path outside = tempDir.resolve("outside.txt");
+    MockMultipartFile file =
+        new MockMultipartFile("file", outside.toString(), "text/plain", "hack".getBytes());
+
+    fileService.uploadFile(root.toString(), "docs", file, null);
+
+    assertFalse(Files.exists(outside));
+    assertTrue(Files.exists(root.resolve("docs/outside.txt")));
+  }
+
+  @Test
+  void uploadFile_blankFilename_throwsInvalidPathException() {
+    MockMultipartFile file = new MockMultipartFile("file", "", "text/plain", "data".getBytes());
+
+    assertThrows(
+        InvalidPathException.class,
+        () -> fileService.uploadFile(tempDir.toString(), "docs", file, null));
+  }
+
   // ── deleteFile ───────────────────────────────────────────────────────────
 
   @Test


### PR DESCRIPTION
## What

`FileService.uploadFile` built the upload target from the raw user-supplied filename without the path validation that `deleteFile`, `renameOrMoveFile` and `readFileContent` already perform:

```java
Path target = folder.resolve(file.getOriginalFilename()); // not validated
Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
```

A crafted `originalFilename` such as `../../x` or an absolute path could make `Files.copy` write **outside** the user's root directory.

## Fix

- Reduce the filename to its final path component (`Paths.get(name).getFileName()`), stripping any directory parts.
- Run the resolved target through the existing `validatePath(rootPath, target)` before copying — defense in depth, consistent with the other file operations.
- Reject uploads with a missing/blank filename.

## Tests

Added to `FileServiceTest`:

- `uploadFile_filenameWithTraversal_staysWithinRoot` — `../../evil.txt` is reduced to its final component inside the folder; nothing escapes the root.
- `uploadFile_absolutePathFilename_staysWithinRoot` — an absolute path as the filename stays within the root.
- `uploadFile_blankFilename_throwsInvalidPathException`.

Full backend suite green locally (92 tests, 0 failures) plus `spotless:check`.

Closes #77
