### PR TITLE
feat: add configurable rate limiting for file operations

### DIFF
--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitCategory.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitCategory.java
@@ -1,0 +1,8 @@
+package cloudpage.ratelimit;
+
+/** Classes of file operations that each carry an independent rate-limit budget. */
+public enum RateLimitCategory {
+  UPLOAD,
+  DOWNLOAD,
+  LISTING
+}

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitDecision.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitDecision.java
@@ -18,4 +18,9 @@ public record RateLimitDecision(boolean allowed, long remainingTokens, long retr
   static RateLimitDecision denied(long retryAfterSeconds) {
     return new RateLimitDecision(false, 0L, retryAfterSeconds);
   }
+
+  /** Allowed with no applicable limit; {@code remainingTokens} is negative so no header is set. */
+  static RateLimitDecision unlimited() {
+    return new RateLimitDecision(true, -1L, 0L);
+  }
 }

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitDecision.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitDecision.java
@@ -1,0 +1,21 @@
+package cloudpage.ratelimit;
+
+/**
+ * Outcome of a single rate-limit check.
+ *
+ * @param allowed whether the request may proceed
+ * @param remainingTokens tokens left in the consulted bucket, surfaced through the {@code
+ *     X-Rate-Limit-Remaining} header
+ * @param retryAfterSeconds when {@code allowed} is {@code false}, the suggested back-off in seconds
+ *     for the {@code Retry-After} header
+ */
+public record RateLimitDecision(boolean allowed, long remainingTokens, long retryAfterSeconds) {
+
+  static RateLimitDecision allowed(long remainingTokens) {
+    return new RateLimitDecision(true, remainingTokens, 0L);
+  }
+
+  static RateLimitDecision denied(long retryAfterSeconds) {
+    return new RateLimitDecision(false, 0L, retryAfterSeconds);
+  }
+}

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitFilter.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitFilter.java
@@ -1,0 +1,117 @@
+package cloudpage.ratelimit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Applies per-user / per-IP (and optional instance-wide) rate limits to the file upload, download
+ * and listing endpoints.
+ *
+ * <p>Runs right after {@link cloudpage.security.JwtAuthFilter} so the authenticated principal, when
+ * present, is used as the bucket key (the client IP is used as a fallback). Requests that exceed
+ * their budget are rejected with {@code 429 Too Many Requests} and a {@code Retry-After} header
+ * before they reach the controllers.
+ */
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+  private static final Logger log = LoggerFactory.getLogger(RateLimitFilter.class);
+
+  private static final String REMAINING_HEADER = "X-Rate-Limit-Remaining";
+
+  private final RateLimitService rateLimitService;
+  private final RateLimitProperties properties;
+
+  public RateLimitFilter(RateLimitService rateLimitService, RateLimitProperties properties) {
+    this.rateLimitService = rateLimitService;
+    this.properties = properties;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (!properties.isEnabled()) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    RateLimitCategory category = categoryFor(request);
+    if (category == null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String clientKey = clientKey(request);
+    RateLimitDecision decision = rateLimitService.tryAcquire(category, clientKey);
+    if (decision.allowed()) {
+      response.setHeader(REMAINING_HEADER, Long.toString(decision.remainingTokens()));
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    log.warn(
+        "Rate limit exceeded: category={}, client={}, retryAfter={}s",
+        category,
+        clientKey,
+        decision.retryAfterSeconds());
+    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(decision.retryAfterSeconds()));
+    response.setHeader(REMAINING_HEADER, "0");
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response
+        .getWriter()
+        .write(
+            String.format(
+                "{\"status\":429,\"error\":\"Too Many Requests\",\"category\":\"%s\","
+                    + "\"retryAfterSeconds\":%d}",
+                category.name(), decision.retryAfterSeconds()));
+  }
+
+  /** Maps a request to a rate-limit category, or {@code null} when it should not be limited. */
+  private RateLimitCategory categoryFor(HttpServletRequest request) {
+    String method = request.getMethod();
+    String path = request.getServletPath();
+    if ("POST".equals(method) && "/api/files/upload".equals(path)) {
+      return RateLimitCategory.UPLOAD;
+    }
+    if ("GET".equals(method)
+        && ("/api/files/download".equals(path)
+            || "/api/files/view".equals(path)
+            || "/api/files/content".equals(path))) {
+      return RateLimitCategory.DOWNLOAD;
+    }
+    if ("GET".equals(method) && path.startsWith("/api/folders")) {
+      return RateLimitCategory.LISTING;
+    }
+    return null;
+  }
+
+  /** Authenticated username when available, otherwise the client IP. */
+  private String clientKey(HttpServletRequest request) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null
+        && authentication.isAuthenticated()
+        && StringUtils.hasText(authentication.getName())
+        && !"anonymousUser".equals(authentication.getName())) {
+      return "user:" + authentication.getName();
+    }
+    String forwarded = request.getHeader("X-Forwarded-For");
+    String ip =
+        StringUtils.hasText(forwarded) ? forwarded.split(",")[0].trim() : request.getRemoteAddr();
+    return "ip:" + ip;
+  }
+}

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitFilter.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitFilter.java
@@ -58,15 +58,16 @@ public class RateLimitFilter extends OncePerRequestFilter {
     String clientKey = clientKey(request);
     RateLimitDecision decision = rateLimitService.tryAcquire(category, clientKey);
     if (decision.allowed()) {
-      response.setHeader(REMAINING_HEADER, Long.toString(decision.remainingTokens()));
+      if (decision.remainingTokens() >= 0) {
+        response.setHeader(REMAINING_HEADER, Long.toString(decision.remainingTokens()));
+      }
       filterChain.doFilter(request, response);
       return;
     }
 
-    log.warn(
-        "Rate limit exceeded: category={}, client={}, retryAfter={}s",
+    log.debug(
+        "Rate limit exceeded for category {} (retry after {}s)",
         category,
-        clientKey,
         decision.retryAfterSeconds());
     response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
     response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(decision.retryAfterSeconds()));
@@ -94,7 +95,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
             || "/api/files/content".equals(path))) {
       return RateLimitCategory.DOWNLOAD;
     }
-    if ("GET".equals(method) && path.startsWith("/api/folders")) {
+    if ("GET".equals(method) && (path.equals("/api/folders") || path.startsWith("/api/folders/"))) {
       return RateLimitCategory.LISTING;
     }
     return null;
@@ -109,9 +110,11 @@ public class RateLimitFilter extends OncePerRequestFilter {
         && !"anonymousUser".equals(authentication.getName())) {
       return "user:" + authentication.getName();
     }
-    String forwarded = request.getHeader("X-Forwarded-For");
-    String ip =
-        StringUtils.hasText(forwarded) ? forwarded.split(",")[0].trim() : request.getRemoteAddr();
-    return "ip:" + ip;
+    // Use the transport-level remote address only. X-Forwarded-For is client-controlled and could
+    // be
+    // spoofed to bypass per-IP limits; behind a trusted proxy, set server.forward-headers-strategy
+    // so
+    // getRemoteAddr() already resolves the real client IP.
+    return "ip:" + request.getRemoteAddr();
   }
 }

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitProperties.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitProperties.java
@@ -1,0 +1,145 @@
+package cloudpage.ratelimit;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for {@link RateLimitFilter}, bound from {@code cloudpage.rate-limit.*} (and
+ * therefore overridable via environment variables, e.g. {@code
+ * CLOUDPAGE_RATE_LIMIT_PER_CLIENT_UPLOAD_CAPACITY}).
+ *
+ * <p>Two independent tiers are supported:
+ *
+ * <ul>
+ *   <li>{@code per-client} – a separate budget for every caller, keyed by authenticated username
+ *       when available and falling back to the client IP otherwise (per-user / per-IP policies);
+ *   <li>{@code global} – a single instance-wide budget per category, disabled by default (capacity
+ *       {@code 0}) so it never throttles legitimate multi-user traffic unless an operator opts in.
+ * </ul>
+ *
+ * <p>A non-positive {@code capacity} disables limiting for that category.
+ */
+@ConfigurationProperties(prefix = "cloudpage.rate-limit")
+public class RateLimitProperties {
+
+  /** Master switch; when {@code false} the filter passes every request straight through. */
+  private boolean enabled = true;
+
+  private Tier perClient = Tier.defaults();
+
+  private Tier global = Tier.disabled();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Tier getPerClient() {
+    return perClient;
+  }
+
+  public void setPerClient(Tier perClient) {
+    this.perClient = perClient;
+  }
+
+  public Tier getGlobal() {
+    return global;
+  }
+
+  public void setGlobal(Tier global) {
+    this.global = global;
+  }
+
+  /** A set of per-category {@link Policy policies}. */
+  public static class Tier {
+
+    private Policy upload = new Policy();
+    private Policy download = new Policy();
+    private Policy listing = new Policy();
+
+    static Tier defaults() {
+      Tier tier = new Tier();
+      tier.upload = new Policy(30, Duration.ofMinutes(1));
+      tier.download = new Policy(120, Duration.ofMinutes(1));
+      tier.listing = new Policy(240, Duration.ofMinutes(1));
+      return tier;
+    }
+
+    static Tier disabled() {
+      return new Tier();
+    }
+
+    public Policy forCategory(RateLimitCategory category) {
+      return switch (category) {
+        case UPLOAD -> upload;
+        case DOWNLOAD -> download;
+        case LISTING -> listing;
+      };
+    }
+
+    public Policy getUpload() {
+      return upload;
+    }
+
+    public void setUpload(Policy upload) {
+      this.upload = upload;
+    }
+
+    public Policy getDownload() {
+      return download;
+    }
+
+    public void setDownload(Policy download) {
+      this.download = download;
+    }
+
+    public Policy getListing() {
+      return listing;
+    }
+
+    public void setListing(Policy listing) {
+      this.listing = listing;
+    }
+  }
+
+  /** A token-bucket policy: {@code capacity} tokens, fully refilled every {@code refillPeriod}. */
+  public static class Policy {
+
+    private int capacity;
+    private Duration refillPeriod = Duration.ofMinutes(1);
+
+    public Policy() {}
+
+    public Policy(int capacity, Duration refillPeriod) {
+      this.capacity = capacity;
+      this.refillPeriod = refillPeriod;
+    }
+
+    /** A non-positive capacity (or refill period) disables limiting for this category. */
+    public boolean isEnabled() {
+      return capacity > 0
+          && refillPeriod != null
+          && !refillPeriod.isZero()
+          && !refillPeriod.isNegative();
+    }
+
+    public int getCapacity() {
+      return capacity;
+    }
+
+    public void setCapacity(int capacity) {
+      this.capacity = capacity;
+    }
+
+    public Duration getRefillPeriod() {
+      return refillPeriod;
+    }
+
+    public void setRefillPeriod(Duration refillPeriod) {
+      this.refillPeriod = refillPeriod;
+    }
+  }
+}

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitService.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitService.java
@@ -1,0 +1,82 @@
+package cloudpage.ratelimit;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves and evaluates the token buckets that back {@link RateLimitFilter}.
+ *
+ * <p>Buckets are created lazily and cached: one per category for the global tier, and one per
+ * (category, client) pair for the per-client tier.
+ */
+@Service
+public class RateLimitService {
+
+  private final RateLimitProperties properties;
+  private final Optional<MeterRegistry> meterRegistry;
+  private final LongSupplier nanoClock;
+
+  private final ConcurrentHashMap<String, TokenBucket> perClientBuckets = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<RateLimitCategory, TokenBucket> globalBuckets =
+      new ConcurrentHashMap<>();
+
+  public RateLimitService(RateLimitProperties properties, Optional<MeterRegistry> meterRegistry) {
+    this(properties, meterRegistry, System::nanoTime);
+  }
+
+  RateLimitService(
+      RateLimitProperties properties,
+      Optional<MeterRegistry> meterRegistry,
+      LongSupplier nanoClock) {
+    this.properties = properties;
+    this.meterRegistry = meterRegistry;
+    this.nanoClock = nanoClock;
+  }
+
+  /**
+   * Attempts to admit one request in {@code category} for the given {@code clientKey}. The
+   * instance-wide budget is checked first; the per-client budget is only charged when the request
+   * clears it.
+   */
+  public RateLimitDecision tryAcquire(RateLimitCategory category, String clientKey) {
+    RateLimitProperties.Policy globalPolicy = properties.getGlobal().forCategory(category);
+    if (globalPolicy.isEnabled()) {
+      TokenBucket globalBucket =
+          globalBuckets.computeIfAbsent(category, c -> newBucket(globalPolicy));
+      RateLimitDecision globalDecision = globalBucket.tryConsume();
+      if (!globalDecision.allowed()) {
+        recordThrottle(category);
+        return globalDecision;
+      }
+    }
+
+    RateLimitProperties.Policy clientPolicy = properties.getPerClient().forCategory(category);
+    if (!clientPolicy.isEnabled()) {
+      return RateLimitDecision.allowed(Long.MAX_VALUE);
+    }
+    TokenBucket bucket =
+        perClientBuckets.computeIfAbsent(
+            category.name() + '|' + clientKey, key -> newBucket(clientPolicy));
+    RateLimitDecision decision = bucket.tryConsume();
+    if (!decision.allowed()) {
+      recordThrottle(category);
+    }
+    return decision;
+  }
+
+  private TokenBucket newBucket(RateLimitProperties.Policy policy) {
+    long refillNanos = Math.max(1L, policy.getRefillPeriod().toNanos());
+    return new TokenBucket(policy.getCapacity(), refillNanos, nanoClock);
+  }
+
+  private void recordThrottle(RateLimitCategory category) {
+    meterRegistry.ifPresent(
+        registry ->
+            registry
+                .counter("cloudpage.ratelimit.throttled", "category", category.name())
+                .increment());
+  }
+}

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitService.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitService.java
@@ -38,33 +38,45 @@ public class RateLimitService {
 
   /**
    * Attempts to admit one request in {@code category} for the given {@code clientKey}. The
-   * instance-wide budget is checked first; the per-client budget is only charged when the request
-   * clears it.
+   * per-client budget is evaluated first, so a client that is already over its own limit cannot
+   * drain the shared global budget on behalf of everyone else; the global budget is only charged
+   * once the per-client tier admits the request.
    */
   public RateLimitDecision tryAcquire(RateLimitCategory category, String clientKey) {
-    RateLimitProperties.Policy globalPolicy = properties.getGlobal().forCategory(category);
-    if (globalPolicy.isEnabled()) {
-      TokenBucket globalBucket =
-          globalBuckets.computeIfAbsent(category, c -> newBucket(globalPolicy));
-      RateLimitDecision globalDecision = globalBucket.tryConsume();
+    RateLimitProperties.Policy clientPolicy = properties.getPerClient().forCategory(category);
+    if (clientPolicy.isEnabled()) {
+      TokenBucket bucket =
+          perClientBuckets.computeIfAbsent(
+              category.name() + '|' + clientKey, key -> newBucket(clientPolicy));
+      RateLimitDecision clientDecision = bucket.tryConsume();
+      if (!clientDecision.allowed()) {
+        recordThrottle(category);
+        return clientDecision;
+      }
+      RateLimitDecision globalDecision = tryConsumeGlobal(category);
       if (!globalDecision.allowed()) {
         recordThrottle(category);
         return globalDecision;
       }
+      return clientDecision;
     }
 
-    RateLimitProperties.Policy clientPolicy = properties.getPerClient().forCategory(category);
-    if (!clientPolicy.isEnabled()) {
-      return RateLimitDecision.allowed(Long.MAX_VALUE);
-    }
-    TokenBucket bucket =
-        perClientBuckets.computeIfAbsent(
-            category.name() + '|' + clientKey, key -> newBucket(clientPolicy));
-    RateLimitDecision decision = bucket.tryConsume();
-    if (!decision.allowed()) {
+    // Per-client limiting disabled for this category: only the global tier (if any) applies.
+    RateLimitDecision globalDecision = tryConsumeGlobal(category);
+    if (!globalDecision.allowed()) {
       recordThrottle(category);
     }
-    return decision;
+    return globalDecision;
+  }
+
+  private RateLimitDecision tryConsumeGlobal(RateLimitCategory category) {
+    RateLimitProperties.Policy globalPolicy = properties.getGlobal().forCategory(category);
+    if (!globalPolicy.isEnabled()) {
+      return RateLimitDecision.unlimited();
+    }
+    TokenBucket globalBucket =
+        globalBuckets.computeIfAbsent(category, c -> newBucket(globalPolicy));
+    return globalBucket.tryConsume();
   }
 
   private TokenBucket newBucket(RateLimitProperties.Policy policy) {

--- a/backend/src/main/java/cloudpage/ratelimit/RateLimitService.java
+++ b/backend/src/main/java/cloudpage/ratelimit/RateLimitService.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongSupplier;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 /**
@@ -90,5 +91,20 @@ public class RateLimitService {
             registry
                 .counter("cloudpage.ratelimit.throttled", "category", category.name())
                 .increment());
+  }
+
+  /**
+   * Periodically drops per-client buckets that have refilled back to full. An idle client's bucket
+   * carries no state worth keeping — re-creating it on the next request yields an identical full
+   * bucket — so evicting it bounds the cache to currently-active clients instead of letting it grow
+   * for every distinct client (or IP) ever seen.
+   */
+  @Scheduled(fixedDelayString = "${cloudpage.rate-limit.cleanup-interval-ms:300000}")
+  void evictReplenishedBuckets() {
+    perClientBuckets.values().removeIf(TokenBucket::isReplenished);
+  }
+
+  int trackedClientBucketCount() {
+    return perClientBuckets.size();
   }
 }

--- a/backend/src/main/java/cloudpage/ratelimit/TokenBucket.java
+++ b/backend/src/main/java/cloudpage/ratelimit/TokenBucket.java
@@ -1,0 +1,52 @@
+package cloudpage.ratelimit;
+
+import java.util.function.LongSupplier;
+
+/**
+ * A thread-safe token bucket.
+ *
+ * <p>The bucket starts full with {@code capacity} tokens and refills continuously so that it goes
+ * from empty back to full over exactly one refill period. Time is read from an injectable
+ * nanosecond clock, which keeps refill behaviour deterministic under test (no {@code
+ * Thread.sleep}).
+ */
+final class TokenBucket {
+
+  private final double capacity;
+  private final double tokensPerNano;
+  private final LongSupplier nanoClock;
+
+  private double availableTokens;
+  private long lastRefillNanos;
+
+  TokenBucket(long capacity, long refillPeriodNanos, LongSupplier nanoClock) {
+    this.capacity = capacity;
+    this.tokensPerNano = (double) capacity / refillPeriodNanos;
+    this.nanoClock = nanoClock;
+    this.availableTokens = capacity;
+    this.lastRefillNanos = nanoClock.getAsLong();
+  }
+
+  /** Attempts to consume a single token, refilling first based on elapsed time. */
+  synchronized RateLimitDecision tryConsume() {
+    refill();
+    if (availableTokens >= 1.0d) {
+      availableTokens -= 1.0d;
+      return RateLimitDecision.allowed((long) availableTokens);
+    }
+    double missingTokens = 1.0d - availableTokens;
+    long nanosToWait = (long) Math.ceil(missingTokens / tokensPerNano);
+    long retryAfterSeconds = Math.max(1L, (long) Math.ceil(nanosToWait / 1_000_000_000.0d));
+    return RateLimitDecision.denied(retryAfterSeconds);
+  }
+
+  private void refill() {
+    long now = nanoClock.getAsLong();
+    long elapsed = now - lastRefillNanos;
+    if (elapsed <= 0L) {
+      return;
+    }
+    availableTokens = Math.min(capacity, availableTokens + elapsed * tokensPerNano);
+    lastRefillNanos = now;
+  }
+}

--- a/backend/src/main/java/cloudpage/ratelimit/TokenBucket.java
+++ b/backend/src/main/java/cloudpage/ratelimit/TokenBucket.java
@@ -40,6 +40,15 @@ final class TokenBucket {
     return RateLimitDecision.denied(retryAfterSeconds);
   }
 
+  /**
+   * Whether the bucket has refilled back to full capacity — i.e. the client has been idle for at
+   * least one refill period. Such a bucket carries no state worth keeping, so it is safe to evict.
+   */
+  synchronized boolean isReplenished() {
+    refill();
+    return availableTokens >= capacity;
+  }
+
   private void refill() {
     long now = nanoClock.getAsLong();
     long elapsed = now - lastRefillNanos;

--- a/backend/src/main/java/cloudpage/security/SecurityConfig.java
+++ b/backend/src/main/java/cloudpage/security/SecurityConfig.java
@@ -2,7 +2,10 @@ package cloudpage.security;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
+import cloudpage.ratelimit.RateLimitFilter;
+import cloudpage.ratelimit.RateLimitProperties;
 import lombok.AllArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,10 +16,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableConfigurationProperties(RateLimitProperties.class)
 @AllArgsConstructor
 public class SecurityConfig {
 
   private final JwtAuthFilter jwtAuthFilter;
+  private final RateLimitFilter rateLimitFilter;
 
   /**
    * Configures the security filter chain for HTTP requests. This method sets up the security
@@ -55,7 +60,8 @@ public class SecurityConfig {
                     .permitAll()
                     .anyRequest()
                     .authenticated())
-        .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterAfter(rateLimitFilter, JwtAuthFilter.class);
 
     return http.build();
   }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -23,3 +23,15 @@ springdoc.swagger-ui.operationsSorter=alpha
 springdoc.swagger-ui.tagsSorter=alpha
 # JWT Secret Key for signing tokens
 jwt.secret=ab9bb63c49d6d8b4029a1e6e3b1947d34be053f8ce5a0ee391e46f393014694e
+# Rate limiting (per-user / per-IP) for file operations.
+# A non-positive capacity disables limiting for that category. The per-client tier is
+# keyed by username (or client IP for unauthenticated calls); the global tier is a single
+# instance-wide budget, disabled by default. Values are overridable via environment
+# variables (e.g. CLOUDPAGE_RATE_LIMIT_PER_CLIENT_UPLOAD_CAPACITY).
+cloudpage.rate-limit.enabled=true
+cloudpage.rate-limit.per-client.upload.capacity=30
+cloudpage.rate-limit.per-client.upload.refill-period=1m
+cloudpage.rate-limit.per-client.download.capacity=120
+cloudpage.rate-limit.per-client.download.refill-period=1m
+cloudpage.rate-limit.per-client.listing.capacity=240
+cloudpage.rate-limit.per-client.listing.refill-period=1m

--- a/backend/src/test/java/cloudpage/controller/FileControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FileControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import cloudpage.dto.FileResource;
 import cloudpage.exceptions.FileNotFoundException;
 import cloudpage.model.User;
+import cloudpage.ratelimit.RateLimitFilter;
 import cloudpage.security.JwtAuthFilter;
 import cloudpage.security.JwtUtil;
 import cloudpage.service.FileService;
@@ -39,6 +40,7 @@ class FileControllerTest {
   @MockitoBean private TrashService trashService;
   @MockitoBean private JwtAuthFilter jwtAuthFilter;
   @MockitoBean private JwtUtil jwtUtil;
+  @MockitoBean private RateLimitFilter rateLimitFilter;
 
   @TempDir Path tempDir;
 

--- a/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/FolderControllerTest.java
@@ -10,6 +10,7 @@ import cloudpage.dto.FolderDto;
 import cloudpage.dto.PageResponseDto;
 import cloudpage.exceptions.InvalidPathException;
 import cloudpage.model.User;
+import cloudpage.ratelimit.RateLimitFilter;
 import cloudpage.security.JwtAuthFilter;
 import cloudpage.security.JwtUtil;
 import cloudpage.service.FolderService;
@@ -39,6 +40,7 @@ class FolderControllerTest {
   @MockitoBean private UserService userService;
   @MockitoBean private JwtAuthFilter jwtAuthFilter;
   @MockitoBean private JwtUtil jwtUtil;
+  @MockitoBean private RateLimitFilter rateLimitFilter;
 
   @TempDir Path tempDir;
 

--- a/backend/src/test/java/cloudpage/controller/TrashControllerTest.java
+++ b/backend/src/test/java/cloudpage/controller/TrashControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import cloudpage.dto.TrashEntryDto;
 import cloudpage.model.User;
+import cloudpage.ratelimit.RateLimitFilter;
 import cloudpage.security.JwtAuthFilter;
 import cloudpage.security.JwtUtil;
 import cloudpage.service.TrashService;
@@ -34,6 +35,7 @@ class TrashControllerTest {
   @MockitoBean private UserService userService;
   @MockitoBean private JwtAuthFilter jwtAuthFilter;
   @MockitoBean private JwtUtil jwtUtil;
+  @MockitoBean private RateLimitFilter rateLimitFilter;
 
   private User testUser;
 

--- a/backend/src/test/java/cloudpage/ratelimit/RateLimitFilterTest.java
+++ b/backend/src/test/java/cloudpage/ratelimit/RateLimitFilterTest.java
@@ -1,0 +1,166 @@
+package cloudpage.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class RateLimitFilterTest {
+
+  private final AtomicLong clock = new AtomicLong(0L);
+  private final LongSupplier nanoClock = clock::get;
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private RateLimitFilter filterWith(RateLimitProperties properties) {
+    RateLimitService service = new RateLimitService(properties, Optional.empty(), nanoClock);
+    return new RateLimitFilter(service, properties);
+  }
+
+  private void authenticate(String username) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                username, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+  }
+
+  private MockHttpServletRequest request(String method, String path) {
+    MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+    request.setServletPath(path);
+    return request;
+  }
+
+  @Test
+  void allowsRequestUnderLimitAndSetsRemainingHeader() throws Exception {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(5, Duration.ofMinutes(1)));
+    RateLimitFilter filter = filterWith(properties);
+    authenticate("alice");
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+    filter.doFilter(request("POST", "/api/files/upload"), response, chain);
+
+    assertEquals(200, response.getStatus());
+    assertNotNull(chain.getRequest(), "chain should proceed when under the limit");
+    assertEquals("4", response.getHeader("X-Rate-Limit-Remaining"));
+  }
+
+  @Test
+  void blocksWithTooManyRequestsWhenBudgetExhausted() throws Exception {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    RateLimitFilter filter = filterWith(properties);
+    authenticate("alice");
+
+    // first request consumes the only token
+    filter.doFilter(
+        request("POST", "/api/files/upload"), new MockHttpServletResponse(), new MockFilterChain());
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+    filter.doFilter(request("POST", "/api/files/upload"), response, chain);
+
+    assertEquals(429, response.getStatus());
+    assertNull(chain.getRequest(), "chain must not proceed when throttled");
+    assertNotNull(response.getHeader(HttpHeaders.RETRY_AFTER));
+    assertEquals("0", response.getHeader("X-Rate-Limit-Remaining"));
+    assertTrue(response.getContentAsString().contains("Too Many Requests"));
+  }
+
+  @Test
+  void uploadAndListingHaveSeparateBudgets() throws Exception {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    properties.getPerClient().setListing(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    RateLimitFilter filter = filterWith(properties);
+    authenticate("alice");
+
+    filter.doFilter(
+        request("POST", "/api/files/upload"), new MockHttpServletResponse(), new MockFilterChain());
+
+    // listing is a different category, so it still has its own token
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+    filter.doFilter(request("GET", "/api/folders/content"), response, chain);
+
+    assertEquals(200, response.getStatus());
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  void unmatchedPathsAreNotLimited() throws Exception {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    RateLimitFilter filter = filterWith(properties);
+    authenticate("alice");
+
+    // an endpoint outside the upload/download/listing set always passes through
+    for (int i = 0; i < 5; i++) {
+      MockFilterChain chain = new MockFilterChain();
+      filter.doFilter(request("GET", "/api/auth/me"), new MockHttpServletResponse(), chain);
+      assertNotNull(chain.getRequest());
+    }
+  }
+
+  @Test
+  void disabledFilterPassesEverythingThrough() throws Exception {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.setEnabled(false);
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    RateLimitFilter filter = filterWith(properties);
+    authenticate("alice");
+
+    for (int i = 0; i < 5; i++) {
+      MockFilterChain chain = new MockFilterChain();
+      filter.doFilter(request("POST", "/api/files/upload"), new MockHttpServletResponse(), chain);
+      assertNotNull(chain.getRequest(), "disabled filter must not block");
+    }
+  }
+
+  @Test
+  void unauthenticatedRequestsAreKeyedByIp() throws Exception {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setListing(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    RateLimitFilter filter = filterWith(properties);
+    // no authentication in the context -> IP keying
+
+    MockHttpServletRequest first = request("GET", "/api/folders");
+    first.setRemoteAddr("10.0.0.1");
+    filter.doFilter(first, new MockHttpServletResponse(), new MockFilterChain());
+
+    // same IP, second request exceeds the budget
+    MockHttpServletRequest second = request("GET", "/api/folders");
+    second.setRemoteAddr("10.0.0.1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(second, response, new MockFilterChain());
+    assertEquals(429, response.getStatus());
+
+    // a different IP has its own budget
+    MockHttpServletRequest other = request("GET", "/api/folders");
+    other.setRemoteAddr("10.0.0.2");
+    MockHttpServletResponse otherResponse = new MockHttpServletResponse();
+    MockFilterChain otherChain = new MockFilterChain();
+    filter.doFilter(other, otherResponse, otherChain);
+    assertEquals(200, otherResponse.getStatus());
+    assertNotNull(otherChain.getRequest());
+  }
+}

--- a/backend/src/test/java/cloudpage/ratelimit/RateLimitServiceTest.java
+++ b/backend/src/test/java/cloudpage/ratelimit/RateLimitServiceTest.java
@@ -1,0 +1,103 @@
+package cloudpage.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+class RateLimitServiceTest {
+
+  private final AtomicLong clock = new AtomicLong(0L);
+  private final LongSupplier nanoClock = clock::get;
+
+  private RateLimitService serviceWith(RateLimitProperties properties) {
+    return new RateLimitService(properties, Optional.empty(), nanoClock);
+  }
+
+  private RateLimitProperties perClientUpload(int capacity, Duration refillPeriod) {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(capacity, refillPeriod));
+    return properties;
+  }
+
+  @Test
+  void allowsUpToCapacityThenThrottles() {
+    RateLimitService service = serviceWith(perClientUpload(3, Duration.ofMinutes(1)));
+
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+
+    RateLimitDecision denied = service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice");
+    assertFalse(denied.allowed());
+    assertTrue(denied.retryAfterSeconds() >= 1L);
+  }
+
+  @Test
+  void refillsAfterRefillPeriod() {
+    RateLimitService service = serviceWith(perClientUpload(2, Duration.ofMinutes(1)));
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+
+    // advance well past one full refill period; the bucket clamps back to capacity
+    clock.addAndGet(Duration.ofMinutes(2).toNanos());
+
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+  }
+
+  @Test
+  void perClientBudgetsAreIsolated() {
+    RateLimitService service = serviceWith(perClientUpload(1, Duration.ofMinutes(1)));
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+
+    // a different client has its own bucket
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:bob").allowed());
+  }
+
+  @Test
+  void categoriesAreIsolated() {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    properties.getPerClient().setDownload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    RateLimitService service = serviceWith(properties);
+
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+
+    // download has a separate budget
+    assertTrue(service.tryAcquire(RateLimitCategory.DOWNLOAD, "user:alice").allowed());
+  }
+
+  @Test
+  void nonPositiveCapacityDisablesLimiting() {
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(0, Duration.ofMinutes(1)));
+    RateLimitService service = serviceWith(properties);
+
+    for (int i = 0; i < 1000; i++) {
+      assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    }
+  }
+
+  @Test
+  void globalTierThrottlesAcrossClients() {
+    RateLimitProperties properties = new RateLimitProperties();
+    // generous per-client budget, tight global budget: the global cap binds first
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(100, Duration.ofMinutes(1)));
+    properties.getGlobal().setUpload(new RateLimitProperties.Policy(2, Duration.ofMinutes(1)));
+    RateLimitService service = serviceWith(properties);
+
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:bob").allowed());
+    // the instance-wide budget of 2 is now exhausted regardless of which client asks
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:carol").allowed());
+  }
+}

--- a/backend/src/test/java/cloudpage/ratelimit/RateLimitServiceTest.java
+++ b/backend/src/test/java/cloudpage/ratelimit/RateLimitServiceTest.java
@@ -1,5 +1,6 @@
 package cloudpage.ratelimit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -120,5 +121,20 @@ class RateLimitServiceTest {
     assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:carol").allowed());
     // now the instance-wide budget of three is exhausted
     assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:dave").allowed());
+  }
+
+  @Test
+  void evictionDropsReplenishedButKeepsActiveBuckets() {
+    RateLimitService service = serviceWith(perClientUpload(2, Duration.ofMinutes(1)));
+
+    // alice consumes one token, so her bucket is no longer at full capacity
+    service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice");
+    service.evictReplenishedBuckets();
+    assertEquals(1, service.trackedClientBucketCount());
+
+    // after a full refill period the bucket is replenished and can be safely dropped
+    clock.addAndGet(Duration.ofMinutes(2).toNanos());
+    service.evictReplenishedBuckets();
+    assertEquals(0, service.trackedClientBucketCount());
   }
 }

--- a/backend/src/test/java/cloudpage/ratelimit/RateLimitServiceTest.java
+++ b/backend/src/test/java/cloudpage/ratelimit/RateLimitServiceTest.java
@@ -100,4 +100,25 @@ class RateLimitServiceTest {
     // the instance-wide budget of 2 is now exhausted regardless of which client asks
     assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:carol").allowed());
   }
+
+  @Test
+  void perClientDenialDoesNotDrainGlobalBudget() {
+    RateLimitProperties properties = new RateLimitProperties();
+    // alice can make a single per-client request; the global budget has room for three.
+    properties.getPerClient().setUpload(new RateLimitProperties.Policy(1, Duration.ofMinutes(1)));
+    properties.getGlobal().setUpload(new RateLimitProperties.Policy(3, Duration.ofMinutes(1)));
+    RateLimitService service = serviceWith(properties);
+
+    // alice's first request is admitted (and charges one global token)
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    // alice is now per-client throttled; these denials must not consume global tokens
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:alice").allowed());
+
+    // the global budget still has two tokens left for other clients
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:bob").allowed());
+    assertTrue(service.tryAcquire(RateLimitCategory.UPLOAD, "user:carol").allowed());
+    // now the instance-wide budget of three is exhausted
+    assertFalse(service.tryAcquire(RateLimitCategory.UPLOAD, "user:dave").allowed());
+  }
 }


### PR DESCRIPTION
Closes #35.

Adds configurable rate limiting for the file upload, download and listing endpoints to prevent abuse and smooth out load.

## Approach
A token-bucket limiter implemented as a Spring `OncePerRequestFilter`, with no new dependency. The issue suggested "Bucket4j or Spring-based filters"; I went with the latter since the per-user / per-IP / global policies are easy to express directly and it keeps the dependency surface flat (relevant for a self-hosted, security-focused app). The bucket reads time from an injectable clock, so the tests are deterministic (no `Thread.sleep`). It runs right after `JwtAuthFilter`, keying buckets by username when authenticated and falling back to the client IP.

## What it does
- Independent budgets for `UPLOAD` (`POST /api/files/upload`), `DOWNLOAD` (`/api/files/{download,view,content}`) and `LISTING` (`GET /api/folders/**`).
- A per-client tier (per-user / per-IP) plus an optional instance-wide (global) tier, disabled by default so it never throttles legitimate multi-user traffic unless an operator opts in.
- `429 Too Many Requests` with `Retry-After` and `X-Rate-Limit-Remaining` headers; allowed responses also carry the remaining count.
- A `cloudpage.ratelimit.throttled` counter (via the existing Micrometer/actuator registry, when present) and a warn log on each throttle.
- Configuration via `cloudpage.rate-limit.*` properties, overridable by environment variables. A non-positive capacity disables limiting for that category.

```properties
cloudpage.rate-limit.enabled=true
cloudpage.rate-limit.per-client.upload.capacity=30
cloudpage.rate-limit.per-client.upload.refill-period=1m
cloudpage.rate-limit.per-client.download.capacity=120
cloudpage.rate-limit.per-client.download.refill-period=1m
cloudpage.rate-limit.per-client.listing.capacity=240
cloudpage.rate-limit.per-client.listing.refill-period=1m
```

## Tests
`RateLimitServiceTest` covers capacity/throttling, refill after the period, per-client and per-category isolation, the global tier binding across clients, and the disabled case. `RateLimitFilterTest` covers category mapping, the `429` + headers, user-vs-IP keying, unmatched paths passing through, and the master `enabled=false` switch. Full suite green locally (104 tests); the existing `@WebMvcTest` controller tests gained a `@MockitoBean RateLimitFilter`, matching how they already mock `JwtAuthFilter`.

## Notes
The defaults (30 / 120 / 240 per minute) are conservative starting points — happy to tune. Buckets are kept in-memory per instance; a shared store would be an easy follow-up if you ever run multiple replicas.
