### PR TITLE
feat: sort folder content by size and last modified, not only name

### DIFF
--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -297,6 +297,12 @@ public class FolderService {
 
     Comparator<FolderContentItemDto> comparator;
     switch (sortField) {
+      case "size":
+        comparator = Comparator.comparingLong(FolderContentItemDto::getSize);
+        break;
+      case "lastModifiedAt":
+        comparator = Comparator.comparingLong(FolderContentItemDto::getLastModifiedAt);
+        break;
       case "name":
       default:
         comparator =

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -314,6 +314,11 @@ public class FolderService {
       comparator = comparator.reversed();
     }
 
+    // Break ties by name so equal primary keys (folders all report size 0, and timestamps can
+    // collide) keep a deterministic order. Names are unique within a folder, so this yields a
+    // total ordering and stops items from being dropped or duplicated across paged requests.
+    comparator = comparator.thenComparing(FolderContentItemDto::getName);
+
     items.sort(comparator);
   }
 

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -9,6 +9,7 @@ import cloudpage.exceptions.InvalidPathException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -292,6 +293,48 @@ class FolderServiceTest {
     assertEquals(1, result.getTotalPages());
     assertEquals(0, result.getPageNumber());
     assertEquals(2, result.getContent().size());
+  }
+
+  @Test
+  void getFolderContentPage_sortByNameDescending_reversesOrder() throws IOException {
+    Files.writeString(tempDir.resolve("a.txt"), "x");
+    Files.writeString(tempDir.resolve("b.txt"), "x");
+    Files.writeString(tempDir.resolve("c.txt"), "x");
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 100, "name,desc");
+
+    assertEquals(
+        List.of("c.txt", "b.txt", "a.txt"),
+        result.getContent().stream().map(FolderContentItemDto::getName).toList());
+  }
+
+  @Test
+  void getFolderContentPage_sortBySizeAscending_ordersBySize() throws IOException {
+    Files.writeString(tempDir.resolve("small.txt"), "x"); // 1 byte
+    Files.writeString(tempDir.resolve("large.txt"), "xxxxx"); // 5 bytes
+    Files.writeString(tempDir.resolve("medium.txt"), "xxx"); // 3 bytes
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 100, "size");
+
+    assertEquals(
+        List.of("small.txt", "medium.txt", "large.txt"),
+        result.getContent().stream().map(FolderContentItemDto::getName).toList());
+  }
+
+  @Test
+  void getFolderContentPage_sortBySizeDescending_ordersBySizeReversed() throws IOException {
+    Files.writeString(tempDir.resolve("small.txt"), "x");
+    Files.writeString(tempDir.resolve("large.txt"), "xxxxx");
+    Files.writeString(tempDir.resolve("medium.txt"), "xxx");
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 100, "size,desc");
+
+    assertEquals(
+        List.of("large.txt", "medium.txt", "small.txt"),
+        result.getContent().stream().map(FolderContentItemDto::getName).toList());
   }
 
   @Test

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -9,6 +9,7 @@ import cloudpage.exceptions.InvalidPathException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -334,6 +335,58 @@ class FolderServiceTest {
 
     assertEquals(
         List.of("large.txt", "medium.txt", "small.txt"),
+        result.getContent().stream().map(FolderContentItemDto::getName).toList());
+  }
+
+  @Test
+  void getFolderContentPage_sortByLastModifiedAscending_ordersByModifiedTime() throws IOException {
+    Path oldest = Files.writeString(tempDir.resolve("oldest.txt"), "x");
+    Path middle = Files.writeString(tempDir.resolve("middle.txt"), "x");
+    Path newest = Files.writeString(tempDir.resolve("newest.txt"), "x");
+    Files.setLastModifiedTime(oldest, FileTime.fromMillis(1_000L));
+    Files.setLastModifiedTime(middle, FileTime.fromMillis(2_000L));
+    Files.setLastModifiedTime(newest, FileTime.fromMillis(3_000L));
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 100, "lastModifiedAt,asc");
+
+    assertEquals(
+        List.of("oldest.txt", "middle.txt", "newest.txt"),
+        result.getContent().stream().map(FolderContentItemDto::getName).toList());
+  }
+
+  @Test
+  void getFolderContentPage_sortByLastModifiedDescending_ordersByModifiedTimeReversed()
+      throws IOException {
+    Path oldest = Files.writeString(tempDir.resolve("oldest.txt"), "x");
+    Path middle = Files.writeString(tempDir.resolve("middle.txt"), "x");
+    Path newest = Files.writeString(tempDir.resolve("newest.txt"), "x");
+    Files.setLastModifiedTime(oldest, FileTime.fromMillis(1_000L));
+    Files.setLastModifiedTime(middle, FileTime.fromMillis(2_000L));
+    Files.setLastModifiedTime(newest, FileTime.fromMillis(3_000L));
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 100, "lastModifiedAt,desc");
+
+    assertEquals(
+        List.of("newest.txt", "middle.txt", "oldest.txt"),
+        result.getContent().stream().map(FolderContentItemDto::getName).toList());
+  }
+
+  @Test
+  void getFolderContentPage_sortBySizeWithTies_breaksTiesByNameForStablePaging()
+      throws IOException {
+    // Every folder reports size 0, so a size sort alone is ambiguous; the name tie-breaker must
+    // give a deterministic order so pagination never drops or duplicates equal-keyed entries.
+    Files.createDirectory(tempDir.resolve("charlie"));
+    Files.createDirectory(tempDir.resolve("alpha"));
+    Files.createDirectory(tempDir.resolve("bravo"));
+
+    PageResponseDto<FolderContentItemDto> result =
+        folderService.getFolderContentPage(tempDir.toString(), "", 0, 100, "size");
+
+    assertEquals(
+        List.of("alpha", "bravo", "charlie"),
         result.getContent().stream().map(FolderContentItemDto::getName).toList());
   }
 


### PR DESCRIPTION
Extends folder-content sorting beyond name. `applySorting` only handled the `name` field, so `size` and `lastModifiedAt` silently fell back to the name comparator. This adds comparators for both, so the existing `field,direction` sort parameter on `GET /api/folders/content` works for them too.

Enables the Cloud Page sorting UI in Vault-Web/vault-web#213.

**Tests:** `FolderServiceTest` gains coverage for name-descending, size-ascending and size-descending ordering (41 pass locally).
