### PR TITLE
feat: add metadata filters and sort controls to folder search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ This service is designed to integrate seamlessly with **Vault Web**, sharing its
 - 🔹 **File Explorer-like API** for user files  
 - 🔹 **CRUD operations** on files and folders  
 - 🔹 **Secure access via JWT tokens** using Vault Web's master key  
+- 🔹 **Fuzzy file search** with metadata filters (type, MIME, size, modified date) and sort controls  
+
+---
+
+## Search
+
+`GET /api/folders/search` performs a fuzzy (Jaro-Winkler) name match and accepts optional metadata
+filters and sort controls:
+
+```
+GET /api/folders/search?folderPath=/&query=report&type=file&minSize=1024&sortBy=size
+```
+
+| Param | Description |
+|-------|-------------|
+| `type` | `file` or `folder` |
+| `mimeType` | MIME-type prefix, e.g. `image` matches `image/png` |
+| `minSize` / `maxSize` | size bounds in bytes |
+| `modifiedAfter` / `modifiedBefore` | last-modified bounds (epoch millis) |
+| `sortBy` | `relevance` (default), `name`, `size`, or `lastModified` |
+| `ascending` | sort direction; defaults to `false` (best / largest / newest first) |
 
 ---
 

--- a/backend/src/main/java/cloudpage/controller/FolderController.java
+++ b/backend/src/main/java/cloudpage/controller/FolderController.java
@@ -3,6 +3,7 @@ package cloudpage.controller;
 import cloudpage.dto.FolderContentItemDto;
 import cloudpage.dto.FolderDto;
 import cloudpage.dto.PageResponseDto;
+import cloudpage.dto.SearchFilter;
 import cloudpage.dto.SearchResult;
 import cloudpage.service.FolderService;
 import cloudpage.service.UserService;
@@ -92,7 +93,8 @@ public class FolderController {
       @RequestParam String folderPath,
       @RequestParam String query,
       @RequestParam(defaultValue = "20") int maxResults,
-      @RequestParam(defaultValue = "60") int minScore)
+      @RequestParam(defaultValue = "60") int minScore,
+      SearchFilter filter)
       throws IOException {
     if (query == null || query.isBlank()) {
       return ResponseEntity.badRequest().build();
@@ -104,6 +106,6 @@ public class FolderController {
     var user = userService.getCurrentUser();
     return ResponseEntity.ok(
         folderService.searchInFolder(
-            user.getRootFolderPath(), folderPath, query, maxResults, validatedMinScore));
+            user.getRootFolderPath(), folderPath, query, maxResults, validatedMinScore, filter));
   }
 }

--- a/backend/src/main/java/cloudpage/dto/SearchFilter.java
+++ b/backend/src/main/java/cloudpage/dto/SearchFilter.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 /**
  * Optional metadata filters and sort controls for the folder search endpoint. All fields are
  * optional; an unset field is not applied. Bound from the query string of {@code GET
- * /folders/search}.
+ * /api/folders/search}.
  */
 @Getter
 @Setter

--- a/backend/src/main/java/cloudpage/dto/SearchFilter.java
+++ b/backend/src/main/java/cloudpage/dto/SearchFilter.java
@@ -1,0 +1,43 @@
+package cloudpage.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Optional metadata filters and sort controls for the folder search endpoint. All fields are
+ * optional; an unset field is not applied. Bound from the query string of {@code GET
+ * /folders/search}.
+ */
+@Getter
+@Setter
+public class SearchFilter {
+
+  /** Restrict results to {@code "file"} or {@code "folder"}; {@code null} keeps both. */
+  private String type;
+
+  /**
+   * Case-insensitive MIME-type prefix, e.g. {@code "image"} matches {@code "image/png"}. Folders
+   * (which have no MIME type) are excluded when this is set.
+   */
+  private String mimeType;
+
+  /** Minimum file size in bytes (inclusive). */
+  private Long minSize;
+
+  /** Maximum file size in bytes (inclusive). */
+  private Long maxSize;
+
+  /** Keep results last modified strictly after this epoch-millis timestamp. */
+  private Long modifiedAfter;
+
+  /** Keep results last modified strictly before this epoch-millis timestamp. */
+  private Long modifiedBefore;
+
+  /**
+   * One of {@code "relevance"} (default), {@code "name"}, {@code "size"}, {@code "lastModified"}.
+   */
+  private String sortBy;
+
+  /** Sort direction. Defaults to descending (best relevance / largest / newest first). */
+  private boolean ascending;
+}

--- a/backend/src/main/java/cloudpage/dto/SearchResult.java
+++ b/backend/src/main/java/cloudpage/dto/SearchResult.java
@@ -13,5 +13,6 @@ public class SearchResult {
   private String type;
   private Long size;
   private String mimeType;
+  private Long lastModifiedAt;
   private int score;
 }

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -81,7 +81,9 @@ public class FolderService {
 
   /** Returns whether a search result satisfies every set metadata filter. */
   private boolean matchesFilter(SearchResult result, SearchFilter filter) {
-    if (filter.getType() != null && !filter.getType().equalsIgnoreCase(result.getType())) {
+    if (filter.getType() != null
+        && !filter.getType().isBlank()
+        && !filter.getType().equalsIgnoreCase(result.getType())) {
       return false;
     }
     if (filter.getMimeType() != null && !filter.getMimeType().isBlank()) {

--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -42,6 +42,17 @@ public class FolderService {
   public List<SearchResult> searchInFolder(
       String rootPath, String folderPath, String query, int maxResults, int minScore)
       throws IOException {
+    return searchInFolder(rootPath, folderPath, query, maxResults, minScore, null);
+  }
+
+  public List<SearchResult> searchInFolder(
+      String rootPath,
+      String folderPath,
+      String query,
+      int maxResults,
+      int minScore,
+      SearchFilter filter)
+      throws IOException {
 
     Path folder = Paths.get(rootPath, folderPath).normalize();
     validatePath(rootPath, folder);
@@ -52,6 +63,7 @@ public class FolderService {
 
     // Locale.ROOT prevents using the system's local language for case conversion
     String lowerQuery = query.toLowerCase(Locale.ROOT);
+    SearchFilter effectiveFilter = filter != null ? filter : new SearchFilter();
 
     Path trashDir = Paths.get(rootPath, TrashService.TRASH_DIR).normalize();
     try (var stream = Files.walk(folder)) {
@@ -60,10 +72,65 @@ public class FolderService {
           .filter(p -> !p.startsWith(trashDir))
           .map(p -> createSearchResult(p, lowerQuery))
           .filter(r -> r.getScore() >= minScore)
-          .sorted((a, b) -> Integer.compare(b.getScore(), a.getScore()))
+          .filter(r -> matchesFilter(r, effectiveFilter))
+          .sorted(searchComparator(effectiveFilter))
           .limit(maxResults)
           .collect(Collectors.toList());
     }
+  }
+
+  /** Returns whether a search result satisfies every set metadata filter. */
+  private boolean matchesFilter(SearchResult result, SearchFilter filter) {
+    if (filter.getType() != null && !filter.getType().equalsIgnoreCase(result.getType())) {
+      return false;
+    }
+    if (filter.getMimeType() != null && !filter.getMimeType().isBlank()) {
+      String mimeType = result.getMimeType();
+      if (mimeType == null
+          || !mimeType
+              .toLowerCase(Locale.ROOT)
+              .startsWith(filter.getMimeType().toLowerCase(Locale.ROOT))) {
+        return false;
+      }
+    }
+    Long size = result.getSize();
+    if (filter.getMinSize() != null && (size == null || size < filter.getMinSize())) {
+      return false;
+    }
+    if (filter.getMaxSize() != null && (size == null || size > filter.getMaxSize())) {
+      return false;
+    }
+    Long modified = result.getLastModifiedAt();
+    if (filter.getModifiedAfter() != null
+        && (modified == null || modified <= filter.getModifiedAfter())) {
+      return false;
+    }
+    return filter.getModifiedBefore() == null
+        || (modified != null && modified < filter.getModifiedBefore());
+  }
+
+  /** Builds the result comparator for the requested sort field and direction. */
+  private Comparator<SearchResult> searchComparator(SearchFilter filter) {
+    String sortBy =
+        filter.getSortBy() == null ? "relevance" : filter.getSortBy().toLowerCase(Locale.ROOT);
+    Comparator<SearchResult> comparator;
+    switch (sortBy) {
+      case "name":
+        comparator = Comparator.comparing(SearchResult::getName, String.CASE_INSENSITIVE_ORDER);
+        break;
+      case "size":
+        comparator =
+            Comparator.comparing((SearchResult r) -> r.getSize() == null ? -1L : r.getSize());
+        break;
+      case "lastmodified":
+        comparator =
+            Comparator.comparing(
+                (SearchResult r) -> r.getLastModifiedAt() == null ? -1L : r.getLastModifiedAt());
+        break;
+      default:
+        comparator = Comparator.comparingInt(SearchResult::getScore);
+    }
+    return filter.isAscending() ? comparator : comparator.reversed();
   }
 
   /**
@@ -97,6 +164,7 @@ public class FolderService {
           isDir ? "folder" : "file",
           isDir ? null : Files.size(path),
           isDir ? null : Files.probeContentType(path),
+          Files.getLastModifiedTime(path).toMillis(),
           score);
     } catch (IOException e) {
       throw new FileNotFoundException("Could not read file or folder: " + path);

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import cloudpage.dto.FolderContentItemDto;
 import cloudpage.dto.FolderDto;
 import cloudpage.dto.PageResponseDto;
+import cloudpage.dto.SearchFilter;
+import cloudpage.dto.SearchResult;
 import cloudpage.exceptions.InvalidPathException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -565,5 +567,99 @@ class FolderServiceTest {
     assertEquals("withFiles", folderItem.getName());
     // 5 + 3 + 2 -> the folder size includes files in nested subfolders
     assertEquals(10, folderItem.getSize());
+  }
+
+  // ── searchInFolder: metadata filters & sorting ───────────────────────────
+
+  @Test
+  void searchInFolder_filterByTypeFile_excludesFolders() throws IOException {
+    Files.writeString(tempDir.resolve("report-file.txt"), "x");
+    Files.createDirectory(tempDir.resolve("report-folder"));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setType("file");
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().allMatch(r -> "file".equals(r.getType())));
+    assertTrue(results.stream().anyMatch(r -> r.getName().equals("report-file.txt")));
+  }
+
+  @Test
+  void searchInFolder_filterBySize_returnsOnlyWithinRange() throws IOException {
+    Files.writeString(tempDir.resolve("report-small.txt"), "ab");
+    Files.writeString(tempDir.resolve("report-large.txt"), "x".repeat(500));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setMinSize(100L);
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals(1, results.size());
+    assertEquals("report-large.txt", results.get(0).getName());
+  }
+
+  @Test
+  void searchInFolder_filterByModifiedAfter_excludesOlder() throws IOException {
+    Path older = tempDir.resolve("report-old.txt");
+    Path newer = tempDir.resolve("report-new.txt");
+    Files.writeString(older, "x");
+    Files.writeString(newer, "x");
+    Files.setLastModifiedTime(older, FileTime.fromMillis(1_000_000L));
+    Files.setLastModifiedTime(newer, FileTime.fromMillis(2_000_000_000_000L));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setModifiedAfter(1_500_000_000_000L);
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals(1, results.size());
+    assertEquals("report-new.txt", results.get(0).getName());
+  }
+
+  @Test
+  void searchInFolder_sortBySize_largestFirstByDefault() throws IOException {
+    Files.writeString(tempDir.resolve("report-small.txt"), "ab");
+    Files.writeString(tempDir.resolve("report-large.txt"), "x".repeat(500));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setSortBy("size");
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals("report-large.txt", results.get(0).getName());
+    assertEquals("report-small.txt", results.get(1).getName());
+  }
+
+  @Test
+  void searchInFolder_sortByNameAscending_ordersAToZ() throws IOException {
+    Files.writeString(tempDir.resolve("report-b.txt"), "x");
+    Files.writeString(tempDir.resolve("report-a.txt"), "x");
+
+    SearchFilter filter = new SearchFilter();
+    filter.setSortBy("name");
+    filter.setAscending(true);
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals("report-a.txt", results.get(0).getName());
+    assertEquals("report-b.txt", results.get(1).getName());
+  }
+
+  @Test
+  void searchInFolder_withoutFilter_returnsAllMatches() throws IOException {
+    Files.writeString(tempDir.resolve("report-a.txt"), "x");
+    Files.writeString(tempDir.resolve("report-b.txt"), "x");
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0);
+
+    assertEquals(2, results.size());
   }
 }

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -662,4 +662,72 @@ class FolderServiceTest {
 
     assertEquals(2, results.size());
   }
+
+  @Test
+  void searchInFolder_sortByLastModified_newestFirstByDefault() throws IOException {
+    Path older = tempDir.resolve("report-old.txt");
+    Path newer = tempDir.resolve("report-new.txt");
+    Files.writeString(older, "x");
+    Files.writeString(newer, "x");
+    Files.setLastModifiedTime(older, FileTime.fromMillis(1_000_000L));
+    Files.setLastModifiedTime(newer, FileTime.fromMillis(2_000_000_000_000L));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setSortBy("lastModified");
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals("report-new.txt", results.get(0).getName());
+    assertEquals("report-old.txt", results.get(1).getName());
+  }
+
+  @Test
+  void searchInFolder_filterByModifiedBefore_excludesNewer() throws IOException {
+    Path older = tempDir.resolve("report-old.txt");
+    Path newer = tempDir.resolve("report-new.txt");
+    Files.writeString(older, "x");
+    Files.writeString(newer, "x");
+    Files.setLastModifiedTime(older, FileTime.fromMillis(1_000_000L));
+    Files.setLastModifiedTime(newer, FileTime.fromMillis(2_000_000_000_000L));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setModifiedBefore(1_500_000_000_000L);
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals(1, results.size());
+    assertEquals("report-old.txt", results.get(0).getName());
+  }
+
+  @Test
+  void searchInFolder_filterByNonMatchingMimeType_returnsEmpty() throws IOException {
+    // .txt files resolve to "text/plain" or null depending on the OS; neither starts with
+    // "image", so the filter must exclude them regardless of the platform's MIME detection.
+    Files.writeString(tempDir.resolve("report-a.txt"), "x");
+    Files.writeString(tempDir.resolve("report-b.txt"), "x");
+
+    SearchFilter filter = new SearchFilter();
+    filter.setMimeType("image");
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void searchInFolder_blankTypeFilter_isIgnored() throws IOException {
+    Files.writeString(tempDir.resolve("report-file.txt"), "x");
+    Files.createDirectory(tempDir.resolve("report-folder"));
+
+    SearchFilter filter = new SearchFilter();
+    filter.setType("");
+
+    List<SearchResult> results =
+        folderService.searchInFolder(tempDir.toString(), "", "report", 20, 0, filter);
+
+    assertEquals(2, results.size());
+  }
 }


### PR DESCRIPTION
## What

Extends the existing fuzzy folder search (`GET /api/folders/search`) with optional **metadata filters** and **sort controls**, addressing the metadata portion of #33:

- **Filters:** `type` (file/folder), `mimeType` (prefix match), `minSize`/`maxSize`, `modifiedAfter`/`modifiedBefore`
- **Sorting:** `sortBy` = `relevance` (default), `name`, `size`, `lastModified`, with an `ascending` toggle
- `SearchResult` now also carries `lastModifiedAt` (used for date filtering and sorting)

The filter/sort options are bound from the query string into a new `SearchFilter` and applied on top of the existing Jaro-Winkler name match. The original call path is unchanged (a backward-compatible overload keeps the no-filter behaviour), so this is purely additive.

## Scope

This covers the metadata querying, filtering and sorting from #33. The **content indexing via a pluggable backend (Lucene / Elasticsearch)** is a larger architectural layer — happy to pick that up as a follow-up in whatever direction you'd prefer for the indexer interface. Marking this as *addresses* rather than *closes* #33 for that reason.

## Tests

6 new `FolderServiceTest` cases cover the type / size / modified-date filters, size & name sorting, and the no-filter backward-compatible path. Full backend suite green locally (`mvn test`): **128 tests, 0 failures**. README updated with the search parameters.

Addresses #33.