### PR TITLE
fix: validate resolved path in createFolder to prevent traversal via folder name

### DIFF
--- a/backend/src/main/java/cloudpage/service/FolderService.java
+++ b/backend/src/main/java/cloudpage/service/FolderService.java
@@ -198,7 +198,8 @@ public class FolderService {
       throws IOException {
     Path parent = Paths.get(rootPath, relativeParentPath).normalize();
     validatePath(rootPath, parent);
-    Path newFolder = parent.resolve(name);
+    Path newFolder = parent.resolve(name).normalize();
+    validatePath(rootPath, newFolder);
     return Files.createDirectory(newFolder);
   }
 

--- a/backend/src/test/java/cloudpage/service/FolderServiceTest.java
+++ b/backend/src/test/java/cloudpage/service/FolderServiceTest.java
@@ -130,6 +130,13 @@ class FolderServiceTest {
         () -> folderService.createFolder(tempDir.toString(), "../../", "hack"));
   }
 
+  @Test
+  void createFolder_pathTraversalViaName_throwsInvalidPathException() {
+    assertThrows(
+        InvalidPathException.class,
+        () -> folderService.createFolder(tempDir.toString(), "", "../../hack"));
+  }
+
   // ── deleteFolder ─────────────────────────────────────────────────────────
 
   @Test


### PR DESCRIPTION
## What

`FolderService.createFolder` validated the parent path but not the resolved target, so a folder `name` containing `..` escaped the user's root. Every other method in the service — `delete`, `rename`, `getFolderTree` — normalizes and re-validates the final path; `createFolder` was the only one that didn't. Same class of bug as #77 (which fixed it for upload); folder creation was missed.

- `createFolder(root, "", "../../hack")` created a directory **outside** the user's root.
- `createFolder(root, "../../", "hack")` was already blocked (the parent argument is validated); only the `name` vector was affected.

## Fix

Normalize the resolved path and run it through the existing `validatePath` guard before `Files.createDirectory`, matching the other methods. Traversal attempts now surface as `InvalidPathException` → `400` via the existing `GlobalExceptionHandler`.

## Test

Added `createFolder_pathTraversalViaName_throwsInvalidPathException` for the `name` vector — the existing traversal test only exercised the parent-path parameter. All 55 `FolderServiceTest` tests pass; spotless clean.

Fixes #87
